### PR TITLE
Implement Params and ParamsInst

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -828,7 +828,7 @@ config.libs = [
         "mw_version": "GC/1.2.5",
         "cflags": cflags_system,
         "objects": [
-            Object(NonMatching, "System/BaseParam.cpp"),
+            Object(Matching, "System/BaseParam.cpp"),
             Object(NonMatching, "System/EmitterViewObj.cpp"),
             Object(NonMatching, "System/EventWatcher.cpp"),
             Object(

--- a/include/JSystem/JSupport/JSUMemoryInputStream.hpp
+++ b/include/JSystem/JSupport/JSUMemoryInputStream.hpp
@@ -7,8 +7,6 @@ class JSUMemoryInputStream : public JSURandomInputStream {
 public:
 	JSUMemoryInputStream(const void* buffer, s32 size)
 	{
-		// Probably an assert
-		(void)!buffer;
 		setBuffer(buffer, size);
 	}
 

--- a/include/Player/MarioInit.hpp
+++ b/include/Player/MarioInit.hpp
@@ -2,471 +2,946 @@
 #define MARIOINIT_HPP
 
 #include "System/ParamInst.hpp"
-
-// TODO: move to a better file
-#include "System/BaseParam.hpp"
-class TParams {
-public:
-	char* filename;
-	TBaseParam* head;
-};
+#include "System/Params.hpp"
 
 // length 0x42C
 class TDeParams : public TParams {
 public:
-	TParamT<s16> hpMax;
-	TParamT<f32> runningMax;
-	TParamT<f32> dashMax;
-	TParamT<f32> dashAcc;
-	TParamT<f32> dashBrake;
-	TParamT<s16> dashStartTime;
-	TParamT<s16> waitingRotSp;
-	TParamT<s16> runningRotSpMin;
-	TParamT<s16> runningRotSpMax;
-	TParamT<s16> rocketRotSp;
-	TParamT<s16> pumpingRotSpMin;
-	TParamT<s16> pumpingRotSpMax;
-	TParamT<s16> invincibleTime;
-	TParamT<s16> footPrintTimerMax;
-	TParamT<u8> waterTriggerRate;
-	TParamT<u8> graffitoNoDmgTime;
-	TParamT<u8> restMax;
-	TParamT<f32> shadowSize;
-	TParamT<f32> shadowErase;
-	TParamT<f32> holdRadius;
-	TParamT<f32> damageRadius;
-	TParamT<f32> damageHeight;
-	TParamT<f32> attackHeight;
-	TParamT<f32> trampleRadius;
-	TParamT<f32> pushupRadius;
-	TParamT<f32> pushupHeight;
-	TParamT<f32> hipdropRadius;
-	TParamT<f32> quakeRadius;
-	TParamT<f32> quakeHeight;
-	TParamT<f32> tramplePowStep1;
-	TParamT<f32> tramplePowStep2;
-	TParamT<f32> tramplePowStep3;
-	TParamT<f32> jumpWallHeight;
-	TParamT<f32> throwPower;
-	TParamT<f32> slipStart;
-	TParamT<f32> wasOnWaterSlip;
-	TParamT<f32> inWaterSlip;
-	TParamT<f32> toroccoRotSp;
-	TParamT<s16> recoverTimer;
-	TParamT<s16> hotTimer;
-	TParamT<f32> feelDeep;
-	TParamT<f32> damageFallHeight;
-	TParamT<f32> forceSlipAngle;
-	TParamT<f32> clashSpeed;
-	TParamT<f32> hangWallMovableAngle;
-	TParamT<f32> colMvMax;
-	TParamT<s16> noFreezeTime;
-	TParamT<s16> kickFreezeTime;
-	TParamT<s16> surfStartFreezeTime;
-	TParamT<f32> sleepingCheckDist;
-	TParamT<f32> sleepingCheckHeight;
-	TParamT<s16> illegalPlaneCtInc;
-	TParamT<s16> illegalPlaneTime;
+	TDeParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mHpMax, 8)
+	    , PARAM_INIT(mRunningMax, 45.0f)
+	    , PARAM_INIT(mDashMax, 60.0f)
+	    , PARAM_INIT(mDashAcc, 0.5f)
+	    , PARAM_INIT(mDashBrake, 0.8f)
+	    , PARAM_INIT(mDashStartTime, 0x78)
+	    , PARAM_INIT(mWaitingRotSp, 0x100)
+	    , PARAM_INIT(mRunningRotSpMin, 0x200)
+	    , PARAM_INIT(mRunningRotSpMax, 0x400)
+	    , PARAM_INIT(mRocketRotSp, 0x100)
+	    , PARAM_INIT(mPumpingRotSpMin, 0x100)
+	    , PARAM_INIT(mPumpingRotSpMax, 0x200)
+	    , PARAM_INIT(mInvincibleTime, 0x14)
+	    , PARAM_INIT(mFootPrintTimerMax, 0x208)
+	    , PARAM_INIT(mWaterTriggerRate, 1)
+	    , PARAM_INIT(mGraffitoNoDmgTime, 10)
+	    , PARAM_INIT(mRestMax, 0xff)
+	    , PARAM_INIT(mShadowSize, 200.0f)
+	    , PARAM_INIT(mShadowErase, 0.2f)
+	    , PARAM_INIT(mHoldRadius, 100.0f)
+	    , PARAM_INIT(mDamageRadius, 42.0f)
+	    , PARAM_INIT(mDamageHeight, 110.0f)
+	    , PARAM_INIT(mAttackHeight, 50.0f)
+	    , PARAM_INIT(mTrampleRadius, 100.0f)
+	    , PARAM_INIT(mPushupRadius, 100.0f)
+	    , PARAM_INIT(mPushupHeight, 200.0f)
+	    , PARAM_INIT(mHipdropRadius, 250.0f)
+	    , PARAM_INIT(mQuakeRadius, 500.0f)
+	    , PARAM_INIT(mQuakeHeight, 500.0f)
+	    , PARAM_INIT(mTramplePowStep1, 30.0f)
+	    , PARAM_INIT(mTramplePowStep2, 40.0f)
+	    , PARAM_INIT(mTramplePowStep3, 50.0f)
+	    , PARAM_INIT(mJumpWallHeight, 1000.0f)
+	    , PARAM_INIT(mThrowPower, 2.0f)
+	    , PARAM_INIT(mSlipStart, 0.34202015f)
+	    , PARAM_INIT(mWasOnWaterSlip, 0.97f)
+	    , PARAM_INIT(mInWaterSlip, 0.89999998f)
+	    , PARAM_INIT(mToroccoRotSp, 1.0f)
+	    , PARAM_INIT(mRecoverTimer, 0xf0)
+	    , PARAM_INIT(mHotTimer, 0x4b0)
+	    , PARAM_INIT(mFeelDeep, 500.0f)
+	    , PARAM_INIT(mDamageFallHeight, 1000.0f)
+	    , PARAM_INIT(mForceSlipAngle, 0.5f)
+	    , PARAM_INIT(mClashSpeed, 50.0f)
+	    , PARAM_INIT(mHangWallMovableAngle, 0.3f)
+	    , PARAM_INIT(mColMvMax, 10.0f)
+	    , PARAM_INIT(mNoFreezeTime, 0x78)
+	    , PARAM_INIT(mKickFreezeTime, 5)
+	    , PARAM_INIT(mSurfStartFreezeTime, 0x78)
+	    , PARAM_INIT(mSleepingCheckDist, 50.0f)
+	    , PARAM_INIT(mSleepingCheckHeight, 30.0f)
+	    , PARAM_INIT(mIllegalPlaneCtInc, 4)
+	    , PARAM_INIT(mIllegalPlaneTime, 0x1e0)
+	{
+	}
+
+	TParamT<s16> mHpMax;
+	TParamT<f32> mRunningMax;
+	TParamT<f32> mDashMax;
+	TParamT<f32> mDashAcc;
+	TParamT<f32> mDashBrake;
+	TParamT<s16> mDashStartTime;
+	TParamT<s16> mWaitingRotSp;
+	TParamT<s16> mRunningRotSpMin;
+	TParamT<s16> mRunningRotSpMax;
+	TParamT<s16> mRocketRotSp;
+	TParamT<s16> mPumpingRotSpMin;
+	TParamT<s16> mPumpingRotSpMax;
+	TParamT<s16> mInvincibleTime;
+	TParamT<s16> mFootPrintTimerMax;
+	TParamT<u8> mWaterTriggerRate;
+	TParamT<u8> mGraffitoNoDmgTime;
+	TParamT<u8> mRestMax;
+	TParamT<f32> mShadowSize;
+	TParamT<f32> mShadowErase;
+	TParamT<f32> mHoldRadius;
+	TParamT<f32> mDamageRadius;
+	TParamT<f32> mDamageHeight;
+	TParamT<f32> mAttackHeight;
+	TParamT<f32> mTrampleRadius;
+	TParamT<f32> mPushupRadius;
+	TParamT<f32> mPushupHeight;
+	TParamT<f32> mHipdropRadius;
+	TParamT<f32> mQuakeRadius;
+	TParamT<f32> mQuakeHeight;
+	TParamT<f32> mTramplePowStep1;
+	TParamT<f32> mTramplePowStep2;
+	TParamT<f32> mTramplePowStep3;
+	TParamT<f32> mJumpWallHeight;
+	TParamT<f32> mThrowPower;
+	TParamT<f32> mSlipStart;
+	TParamT<f32> mWasOnWaterSlip;
+	TParamT<f32> mInWaterSlip;
+	TParamT<f32> mToroccoRotSp;
+	TParamT<s16> mRecoverTimer;
+	TParamT<s16> mHotTimer;
+	TParamT<f32> mFeelDeep;
+	TParamT<f32> mDamageFallHeight;
+	TParamT<f32> mForceSlipAngle;
+	TParamT<f32> mClashSpeed;
+	TParamT<f32> mHangWallMovableAngle;
+	TParamT<f32> mColMvMax;
+	TParamT<s16> mNoFreezeTime;
+	TParamT<s16> mKickFreezeTime;
+	TParamT<s16> mSurfStartFreezeTime;
+	TParamT<f32> mSleepingCheckDist;
+	TParamT<f32> mSleepingCheckHeight;
+	TParamT<s16> mIllegalPlaneCtInc;
+	TParamT<s16> mIllegalPlaneTime;
 };
 
 class TBodyAngleParams : public TParams {
 public:
-	TParamT<f32> headRot;
-	TParamT<f32> waistRoll;
-	TParamT<f32> waistPitch;
-	TParamT<s16> waistRollMax;
-	TParamT<s16> waistPitchMax;
-	TParamT<f32> waistAngleChangeRate;
+	TBodyAngleParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mHeadRot, 0.0f)
+	    , PARAM_INIT(mWaistRoll, 0.0f)
+	    , PARAM_INIT(mWaistPitch, 80.0f)
+	    , PARAM_INIT(mWaistRollMax, 0)
+	    , PARAM_INIT(mWaistPitchMax, 1000)
+	    , PARAM_INIT(mWaistAngleChangeRate, 0.07f)
+	{
+	}
+	TParamT<f32> mHeadRot;
+	TParamT<f32> mWaistRoll;
+	TParamT<f32> mWaistPitch;
+	TParamT<s16> mWaistRollMax;
+	TParamT<s16> mWaistPitchMax;
+	TParamT<f32> mWaistAngleChangeRate;
 };
 
 class TAttackParams : public TParams {
 public:
-	TParamT<f32> radius;
-	TParamT<f32> height;
+	TAttackParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mRadius, 100.0f)
+	    , PARAM_INIT(mHeight, 50.0f)
+	{
+	}
+	TParamT<f32> mRadius;
+	TParamT<f32> mHeight;
 };
 
 class THangingParams : public TParams {
 public:
-	TParamT<f32> moveS;
-	TParamT<f32> anmRate;
-	TParamT<s16> rapidTime;
-	TParamT<s16> limitTime;
-	TParamT<f32> anmRapid;
-	TParamT<f32> descentSp;
+	THangingParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mMoveS, 0.1f)
+	    , PARAM_INIT(mAnmRate, 0.5f)
+	    , PARAM_INIT(mRapidTime, 2000)
+	    , PARAM_INIT(mLimitTime, 0x960)
+	    , PARAM_INIT(mAnmRapid, 8.0f)
+	    , PARAM_INIT(mDescentSp, 10.0f)
+	{
+	}
+	TParamT<f32> mMoveS;
+	TParamT<f32> mAnmRate;
+	TParamT<s16> mRapidTime;
+	TParamT<s16> mLimitTime;
+	TParamT<f32> mAnmRapid;
+	TParamT<f32> mDescentSp;
 };
 
 class TPullParams : public TParams {
 public:
-	TParamT<f32> pullRateV;
-	TParamT<f32> pullRateH;
-	TParamT<f32> oilPullRateV;
-	TParamT<f32> oilPullRateH;
+	TPullParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mPullRateV, 0.3f)
+	    , PARAM_INIT(mPullRateH, 0.05f)
+	    , PARAM_INIT(mOilPullRateV, 0.1f)
+	    , PARAM_INIT(mOilPullRateH, 0.0099999998f)
+	{
+	}
+
+	TParamT<f32> mPullRateV;
+	TParamT<f32> mPullRateH;
+	TParamT<f32> mOilPullRateV;
+	TParamT<f32> mOilPullRateH;
 };
 
 class TDmgParams : public TParams {
 public:
-	TParamT<u8> damage;
-	TParamT<u8> downType;
-	TParamT<u8> waterEmit;
-	TParamT<u8> motor;
-	TParamT<f32> minSpeed;
-	TParamT<f32> dirty;
-	TParamT<s16> invincibleTime;
+	TDmgParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mDamage, 1)
+	    , PARAM_INIT(mDownType, 0)
+	    , PARAM_INIT(mWaterEmit, 0)
+	    , PARAM_INIT(mMotor, 0)
+	    , PARAM_INIT(mMinSpeed, 0.0f)
+	    , PARAM_INIT(mDirty, 0.0f)
+	    , PARAM_INIT(mInvincibleTime, 0)
+	{
+	}
+
+	TParamT<u8> mDamage;
+	TParamT<u8> mDownType;
+	TParamT<u8> mWaterEmit;
+	TParamT<u8> mMotor;
+	TParamT<f32> mMinSpeed;
+	TParamT<f32> mDirty;
+	TParamT<s16> mInvincibleTime;
 };
 
 class TUpperBodyParams : public TParams {
 public:
-	TParamT<s16> pumpWaitTime;
-	TParamT<f32> pumpAnmSpeed;
-	TParamT<s16> hoverHeadAngle;
-	TParamT<s16> feelDeepHeadAngle;
-	TParamT<s16> frontWallHeadAngle;
+	TUpperBodyParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mPumpWaitTime, 10)
+	    , PARAM_INIT(mPumpAnmSpeed, 0.0099999998f)
+	    , PARAM_INIT(mHoverHeadAngle, 0xe000)
+	    , PARAM_INIT(mFeelDeepHeadAngle, 0x2000)
+	    , PARAM_INIT(mFrontWallHeadAngle, 0xe000)
+	{
+	}
+
+	TParamT<s16> mPumpWaitTime;
+	TParamT<f32> mPumpAnmSpeed;
+	TParamT<s16> mHoverHeadAngle;
+	TParamT<s16> mFeelDeepHeadAngle;
+	TParamT<s16> mFrontWallHeadAngle;
 };
 
 class TBarParams : public TParams {
 public:
-	TParamT<f32> climbSp;
-	TParamT<f32> rotateSp;
-	TParamT<f32> climbAnmRate;
-	TParamT<f32> catchRadius;
-	TParamT<f32> catchAngle;
+	TBarParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mClimbSp, 0.035f)
+	    , PARAM_INIT(mRotateSp, 3.0f)
+	    , PARAM_INIT(mClimbAnmRate, 0.00390625f)
+	    , PARAM_INIT(mCatchRadius, 100.0f)
+	    , PARAM_INIT(mCatchAngle, 0.8f)
+	{
+	}
+
+	TParamT<f32> mClimbSp;
+	TParamT<f32> mRotateSp;
+	TParamT<f32> mClimbAnmRate;
+	TParamT<f32> mCatchRadius;
+	TParamT<f32> mCatchAngle;
 };
 
 class TSoundParams : public TParams {
 public:
-	TParamT<f32> startFallVoiceSpeed;
+	TSoundParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mStartFallVoiceSpeed, 60.0f)
+	{
+	}
+
+	TParamT<f32> mStartFallVoiceSpeed;
 };
 
 class TOptionParams : public TParams {
 public:
-	TParamT<f32> z;
-	TParamT<f32> xMin;
-	TParamT<f32> xMax;
+	TOptionParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mZ, -1000.0f)
+	    , PARAM_INIT(mXMin, 846.0f)
+	    , PARAM_INIT(mXMax, 2000.0f)
+	{
+	}
+
+	TParamT<f32> mZ;
+	TParamT<f32> mXMin;
+	TParamT<f32> mXMax;
 };
 
 class TMarioEffectParams : public TParams {
 public:
-	TParamT<f32> dashInc;
-	TParamT<f32> dashDec;
-	TParamT<u8> dashMaxBlendInBlur;
-	TParamT<u8> dashMaxBlendInIris;
-	TParamT<f32> dashBlendScale;
+	TMarioEffectParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mDashInc, 0.033333335f)
+	    , PARAM_INIT(mDashDec, 0.016666668f)
+	    , PARAM_INIT(mDashMaxBlendInBlur, 0xb4)
+	    , PARAM_INIT(mDashMaxBlendInIris, 0xb4)
+	    , PARAM_INIT(mDashBlendScale, 0.2f)
+	{
+	}
+
+	TParamT<f32> mDashInc;
+	TParamT<f32> mDashDec;
+	TParamT<u8> mDashMaxBlendInBlur;
+	TParamT<u8> mDashMaxBlendInIris;
+	TParamT<f32> mDashBlendScale;
 };
 
 class THoverParams : public TParams {
 public:
-	TParamT<s16> rotSp;
-	TParamT<f32> accelRate;
-	TParamT<f32> brake;
+	THoverParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mRotSp, 0x80)
+	    , PARAM_INIT(mAccelRate, 0.029999999f)
+	    , PARAM_INIT(mBrake, 0.94999999f)
+	{
+	}
+
+	TParamT<s16> mRotSp;
+	TParamT<f32> mAccelRate;
+	TParamT<f32> mBrake;
 };
 
 class TDivingParams : public TParams {
 public:
-	TParamT<s16> rotSp;
-	TParamT<f32> gravity;
-	TParamT<f32> accelControl;
-	TParamT<f32> seaBrake;
-	TParamT<f32> seaBrakeY;
+	TDivingParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mRotSp, 0x80)
+	    , PARAM_INIT(mGravity, 0.5f)
+	    , PARAM_INIT(mAccelControl, 0.02f)
+	    , PARAM_INIT(mSeaBrake, 0.999f)
+	    , PARAM_INIT(mSeaBrakeY, 0.98f)
+	{
+	}
+
+	TParamT<s16> mRotSp;
+	TParamT<f32> mGravity;
+	TParamT<f32> mAccelControl;
+	TParamT<f32> mSeaBrake;
+	TParamT<f32> mSeaBrakeY;
 };
 
 class TYoshiParams : public TParams {
 public:
-	TParamT<f32> runYoshiMult;
-	TParamT<f32> jumpYoshiMult;
-	TParamT<f32> rotYoshiMult;
-	TParamT<f32> headFront;
-	TParamT<f32> headRadius;
-	TParamT<f32> holdOutAccCtrlF;
-	TParamT<f32> holdOutAccCtrlB;
-	TParamT<f32> holdOutSldCtrl;
-	TParamT<f32> decBrake;
+	TYoshiParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mRunYoshiMult, 1.2f)
+	    , PARAM_INIT(mJumpYoshiMult, 1.0f)
+	    , PARAM_INIT(mRotYoshiMult, 1.5f)
+	    , PARAM_INIT(mHeadFront, 80.0f)
+	    , PARAM_INIT(mHeadRadius, 50.0f)
+	    , PARAM_INIT(mHoldOutAccCtrlF, 0.0099999998f)
+	    , PARAM_INIT(mHoldOutAccCtrlB, 0.023f)
+	    , PARAM_INIT(mHoldOutSldCtrl, 0.3f)
+	    , PARAM_INIT(mDecBrake, 1.0f)
+	{
+	}
+
+	TParamT<f32> mRunYoshiMult;
+	TParamT<f32> mJumpYoshiMult;
+	TParamT<f32> mRotYoshiMult;
+	TParamT<f32> mHeadFront;
+	TParamT<f32> mHeadRadius;
+	TParamT<f32> mHoldOutAccCtrlF;
+	TParamT<f32> mHoldOutAccCtrlB;
+	TParamT<f32> mHoldOutSldCtrl;
+	TParamT<f32> mDecBrake;
 };
 
 class THangRoofParams : public TParams {
 public:
-	TParamT<f32> anmMult;
+	THangRoofParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mAnmMult, 0.3f)
+	{
+	}
+
+	TParamT<f32> mAnmMult;
 };
 
 class TWireParams : public TParams {
 public:
-	TParamT<s16> rotSpeed;
-	TParamT<s16> rotSpeedTrgHover;
-	TParamT<s16> rotSpeedTrgTurbo;
-	TParamT<s16> rotSpeedTrgRocket;
-	TParamT<s16> rotSpeedMax;
-	TParamT<s16> rotStop;
-	TParamT<s16> rotGravity;
-	TParamT<f32> rotBrake;
-	TParamT<f32> jumpRate;
-	TParamT<s32> swingRate;
-	TParamT<f32> wireJumpAccelControl;
-	TParamT<f32> wireJumpSlideControl;
-	TParamT<f32> wireJumpMult;
-	TParamT<f32> wireJumpBase;
-	TParamT<f32> wireSwingBrake;
-	TParamT<f32> wireSwingMax;
+	TWireParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mRotSpeed, -8)
+	    , PARAM_INIT(mRotSpeedTrgHover, 8)
+	    , PARAM_INIT(mRotSpeedTrgTurbo, 1000)
+	    , PARAM_INIT(mRotSpeedTrgRocket, 1000)
+	    , PARAM_INIT(mRotSpeedMax, 0x578)
+	    , PARAM_INIT(mRotStop, 100)
+	    , PARAM_INIT(mRotGravity, 0x14)
+	    , PARAM_INIT(mRotBrake, 0.98f)
+	    , PARAM_INIT(mJumpRate, 0.09f)
+	    , PARAM_INIT(mSwingRate, 0.0049999999f)
+	    , PARAM_INIT(mWireJumpAccelControl, 0.0099999998f)
+	    , PARAM_INIT(mWireJumpSlideControl, 0.3f)
+	    , PARAM_INIT(mWireJumpMult, 5.0f)
+	    , PARAM_INIT(mWireJumpBase, 20.0f)
+	    , PARAM_INIT(mWireSwingBrake, 0.99f)
+	    , PARAM_INIT(mWireSwingMax, 100.0f)
+	{
+	}
+
+	TParamT<s16> mRotSpeed;
+	TParamT<s16> mRotSpeedTrgHover;
+	TParamT<s16> mRotSpeedTrgTurbo;
+	TParamT<s16> mRotSpeedTrgRocket;
+	TParamT<s16> mRotSpeedMax;
+	TParamT<s16> mRotStop;
+	TParamT<s16> mRotGravity;
+	TParamT<f32> mRotBrake;
+	TParamT<f32> mJumpRate;
+	TParamT<s32> mSwingRate;
+	TParamT<f32> mWireJumpAccelControl;
+	TParamT<f32> mWireJumpSlideControl;
+	TParamT<f32> mWireJumpMult;
+	TParamT<f32> mWireJumpBase;
+	TParamT<f32> mWireSwingBrake;
+	TParamT<f32> mWireSwingMax;
 };
 
 class TAutoDemoParams : public TParams {
 public:
-	TParamT<s16> warpInBallsDispTime;
-	TParamT<s16> warpInBallsTime;
-	TParamT<s16> warpInCapturedTime;
-	TParamT<f32> warpInTremble;
-	TParamT<f32> warpInVecBase;
-	TParamT<f32> warpTransTremble;
-	TParamT<s16> readRotSp;
+	TAutoDemoParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mWarpInBallsDispTime, 6)
+	    , PARAM_INIT(mWarpInBallsTime, 0x46)
+	    , PARAM_INIT(mWarpInCapturedTime, 0x78)
+	    , PARAM_INIT(mWarpInTremble, 15.0f)
+	    , PARAM_INIT(mWarpInVecBase, 0.3f)
+	    , PARAM_INIT(mWarpTransTremble, 50.0f)
+	    , PARAM_INIT(mReadRotSp, 0x400f)
+	{
+	}
+
+	TParamT<s16> mWarpInBallsDispTime;
+	TParamT<s16> mWarpInBallsTime;
+	TParamT<s16> mWarpInCapturedTime;
+	TParamT<f32> mWarpInTremble;
+	TParamT<f32> mWarpInVecBase;
+	TParamT<f32> mWarpTransTremble;
+	TParamT<s16> mReadRotSp;
 };
 
 class TSlipParams : TParams {
 public:
-	TParamT<f32> slipFriction;
-	TParamT<f32> slopeAccelUp;
-	TParamT<f32> slopeAccelDown;
-	TParamT<f32> slideAccelUp;
-	TParamT<f32> slideAccelDown;
-	TParamT<f32> slideAccelNormal;
-	TParamT<f32> slideStopCatch;
-	TParamT<u8> jumpEnable;
-	TParamT<f32> missJump;
-	TParamT<f32> slideAngleYSp;
-	TParamT<f32> stickSlideMult;
+	TSlipParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mSlipFriction, 0.89999998f)
+	    , PARAM_INIT(mSlopeAccelUp, 0.0f)
+	    , PARAM_INIT(mSlopeAccelDown, 0.0f)
+	    , PARAM_INIT(mSlideAccelUp, 0.0f)
+	    , PARAM_INIT(mSlideAccelDown, 0.0f)
+	    , PARAM_INIT(mSlideAccelNormal, 15.0f)
+	    , PARAM_INIT(mSlideStopCatch, 15.0f)
+	    , PARAM_INIT(mJumpEnable, 1)
+	    , PARAM_INIT(mMissJump, 1)
+	    , PARAM_INIT(mSlideAngleYSp, 0x200)
+	    , PARAM_INIT(mStickSlideMult, 0.05f)
+	{
+	}
+
+	TParamT<f32> mSlipFriction;
+	TParamT<f32> mSlopeAccelUp;
+	TParamT<f32> mSlopeAccelDown;
+	TParamT<f32> mSlideAccelUp;
+	TParamT<f32> mSlideAccelDown;
+	TParamT<f32> mSlideAccelNormal;
+	TParamT<f32> mSlideStopCatch;
+	TParamT<u8> mJumpEnable;
+	TParamT<u8> mMissJump;
+	TParamT<s16> mSlideAngleYSp;
+	TParamT<f32> mStickSlideMult;
 };
 
 class TWaterEffectParams : public TParams {
 public:
-	TParamT<f32> jumpIntoMdlEffectSpY;
-	TParamT<f32> jumpIntoMinY;
-	TParamT<f32> jumpIntoMaxY;
-	TParamT<f32> jumpIntoScaleMin;
-	TParamT<f32> jumpIntoScaleWidth;
-	TParamT<f32> runningRippleSpeed;
-	TParamT<f32> runningRippleDepth;
+	TWaterEffectParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mJumpIntoMdlEffectSpY, 10.0f)
+	    , PARAM_INIT(mJumpIntoMinY, 20.0f)
+	    , PARAM_INIT(mJumpIntoMaxY, 50.0f)
+	    , PARAM_INIT(mJumpIntoScaleMin, 0.75f)
+	    , PARAM_INIT(mJumpIntoScaleWidth, 1.0f)
+	    , PARAM_INIT(mRunningRippleSpeed, 30.0f)
+	    , PARAM_INIT(mRunningRippleDepth, 30.0f)
+	{
+	}
+
+	TParamT<f32> mJumpIntoMdlEffectSpY;
+	TParamT<f32> mJumpIntoMinY;
+	TParamT<f32> mJumpIntoMaxY;
+	TParamT<f32> mJumpIntoScaleMin;
+	TParamT<f32> mJumpIntoScaleWidth;
+	TParamT<f32> mRunningRippleSpeed;
+	TParamT<f32> mRunningRippleDepth;
 };
 
 class TDirtyParams : TParams {
 public:
-	TParamT<f32> incRunning;
-	TParamT<f32> incCatching;
-	TParamT<f32> incSlipping;
-	TParamT<f32> decSwimming;
-	TParamT<f32> decWaterHit;
-	TParamT<f32> decRotJump;
-	TParamT<f32> brakeStartValSlip;
-	TParamT<f32> brakeStartValRun;
-	TParamT<s16> dirtyTimeSlip;
-	TParamT<s16> dirtyTimeRun;
-	TParamT<f32> polSizeSlip;
-	TParamT<f32> polSizeRun;
-	TParamT<f32> polSizeFootPrint;
-	TParamT<f32> polSizeJump;
-	TParamT<f32> slopeAngle;
-	TParamT<f32> dirtyMax;
-	TParamT<f32> slipAnmSpeed;
-	TParamT<f32> slipRunSp;
-	TParamT<f32> slipCatchSp;
-	TParamT<s16> slipRotate;
-	TParamT<s16> slipCatchRotate;
-	TParamT<f32> brakeSlipNoPollute;
-	TParamT<s16> fogTimeYellow;
-	TParamT<s16> fogTimeRed;
+	TDirtyParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mIncRunning, 0.1f)
+	    , PARAM_INIT(mIncCatching, 0.3f)
+	    , PARAM_INIT(mIncSlipping, 0.2f)
+	    , PARAM_INIT(mDecSwimming, 0.5f)
+	    , PARAM_INIT(mDecWaterHit, 0.2f)
+	    , PARAM_INIT(mDecRotJump, 0.1f)
+	    , PARAM_INIT(mBrakeStartValSlip, 0.99f)
+	    , PARAM_INIT(mBrakeStartValRun, 0.98f)
+	    , PARAM_INIT(mDirtyTimeSlip, 600)
+	    , PARAM_INIT(mDirtyTimeRun, 600)
+	    , PARAM_INIT(mPolSizeSlip, 200.0f)
+	    , PARAM_INIT(mPolSizeRun, 80.0f)
+	    , PARAM_INIT(mPolSizeFootPrint, 200.0f)
+	    , PARAM_INIT(mPolSizeJump, 200.0f)
+	    , PARAM_INIT(mSlopeAngle, 0.99f)
+	    , PARAM_INIT(mDirtyMax, 200.0f)
+	    , PARAM_INIT(mSlipAnmSpeed, 3.0f)
+	    , PARAM_INIT(mSlipRunSp, 0.0099999998f)
+	    , PARAM_INIT(mSlipCatchSp, 0.0099999998f)
+	    , PARAM_INIT(mSlipRotate, 0x100)
+	    , PARAM_INIT(mSlipCatchRotate, 0x100)
+	    , PARAM_INIT(mBrakeSlipNoPollute, 0.98f)
+	    , PARAM_INIT(mFogTimeYellow, 0xf0)
+	    , PARAM_INIT(mFogTimeRed, 600)
+	{
+	}
+
+	TParamT<f32> mIncRunning;
+	TParamT<f32> mIncCatching;
+	TParamT<f32> mIncSlipping;
+	TParamT<f32> mDecSwimming;
+	TParamT<f32> mDecWaterHit;
+	TParamT<f32> mDecRotJump;
+	TParamT<f32> mBrakeStartValSlip;
+	TParamT<f32> mBrakeStartValRun;
+	TParamT<s16> mDirtyTimeSlip;
+	TParamT<s16> mDirtyTimeRun;
+	TParamT<f32> mPolSizeSlip;
+	TParamT<f32> mPolSizeRun;
+	TParamT<f32> mPolSizeFootPrint;
+	TParamT<f32> mPolSizeJump;
+	TParamT<f32> mSlopeAngle;
+	TParamT<f32> mDirtyMax;
+	TParamT<f32> mSlipAnmSpeed;
+	TParamT<f32> mSlipRunSp;
+	TParamT<f32> mSlipCatchSp;
+	TParamT<s16> mSlipRotate;
+	TParamT<s16> mSlipCatchRotate;
+	TParamT<f32> mBrakeSlipNoPollute;
+	TParamT<s16> mFogTimeYellow;
+	TParamT<s16> mFogTimeRed;
 };
 
 class TMarioMotorParams : TParams {
 public:
-	TParamT<s16> motorReturn;
-	TParamT<s16> motorTrample;
-	TParamT<s16> motorHipDrop;
-	TParamT<s16> motorWall;
+	TMarioMotorParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mMotorReturn, 0x19)
+	    , PARAM_INIT(mMotorTrample, 8)
+	    , PARAM_INIT(mMotorHipDrop, 0xf)
+	    , PARAM_INIT(mMotorWall, 6)
+	{
+	}
+
+	TParamT<s16> mMotorReturn;
+	TParamT<s16> mMotorTrample;
+	TParamT<s16> mMotorHipDrop;
+	TParamT<s16> mMotorWall;
 };
 
 class TSwimParams : TParams {
 public:
-	TParamT<f32> startSp;
-	TParamT<f32> moveSp;
-	TParamT<f32> moveBrake;
-	TParamT<s16> swimmingRotSpMin;
-	TParamT<s16> swimmingRotSpMax;
-	TParamT<s16> pumpingRotSpMin;
-	TParamT<s16> pumpingRotSpMax;
-	TParamT<f32> gravity;
-	TParamT<f32> waitBouyancy;
-	TParamT<f32> moveBouyancy;
-	TParamT<f32> upDownBrake;
-	TParamT<f32> canJumpDepth;
-	TParamT<f32> endDepth;
-	TParamT<f32> floatHeight;
-	TParamT<f32> startVMult;
-	TParamT<f32> startVYMult;
-	TParamT<f32> rush;
-	TParamT<f32> anmBrake;
-	TParamT<f32> paddleSpeedUp;
-	TParamT<f32> paddleJumpUp;
-	TParamT<f32> floatUp;
-	TParamT<f32> waterLevelCheckHeight;
-	TParamT<f32> paddleDown;
-	TParamT<s16> waitSinkTime;
-	TParamT<f32> canBreathDepth;
-	TParamT<f32> waitSinkSpeed;
-	TParamT<f32> airDec;
-	TParamT<f32> airDecDive;
-	TParamT<f32> airInc;
+	TSwimParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mStartSp, 1.0f)
+	    , PARAM_INIT(mMoveSp, 0.8f)
+	    , PARAM_INIT(mMoveBrake, 1.0f)
+	    , PARAM_INIT(mSwimmingRotSpMin, 0x200)
+	    , PARAM_INIT(mSwimmingRotSpMax, 0x400)
+	    , PARAM_INIT(mPumpingRotSpMin, 0x100)
+	    , PARAM_INIT(mPumpingRotSpMax, 0x200)
+	    , PARAM_INIT(mGravity, 0.1f)
+	    , PARAM_INIT(mWaitBouyancy, 1.0f)
+	    , PARAM_INIT(mMoveBouyancy, 1.0f)
+	    , PARAM_INIT(mUpDownBrake, 0.94999999f)
+	    , PARAM_INIT(mCanJumpDepth, 1.0f)
+	    , PARAM_INIT(mEndDepth, 80.0f)
+	    , PARAM_INIT(mFloatHeight, 120.0f)
+	    , PARAM_INIT(mStartVMult, 0.1f)
+	    , PARAM_INIT(mStartVYMult, 0.1f)
+	    , PARAM_INIT(mRush, 3.0f)
+	    , PARAM_INIT(mAnmBrake, 0.02f)
+	    , PARAM_INIT(mPaddleSpeedUp, 0.3f)
+	    , PARAM_INIT(mPaddleJumpUp, 1.0f)
+	    , PARAM_INIT(mFloatUp, 2.0f)
+	    , PARAM_INIT(mWaterLevelCheckHeight, 10.0f)
+	    , PARAM_INIT(mPaddleDown, 1.0f)
+	    , PARAM_INIT(mWaitSinkTime, 0x32)
+	    , PARAM_INIT(mCanBreathDepth, 50.0f)
+	    , PARAM_INIT(mWaitSinkSpeed, 5.0f)
+	    , PARAM_INIT(mAirDec, 0.001f)
+	    , PARAM_INIT(mAirDecDive, 0.001f)
+	    , PARAM_INIT(mAirInc, 0.029999999f)
+	{
+	}
+
+	TParamT<f32> mStartSp;
+	TParamT<f32> mMoveSp;
+	TParamT<f32> mMoveBrake;
+	TParamT<s16> mSwimmingRotSpMin;
+	TParamT<s16> mSwimmingRotSpMax;
+	TParamT<s16> mPumpingRotSpMin;
+	TParamT<s16> mPumpingRotSpMax;
+	TParamT<f32> mGravity;
+	TParamT<f32> mWaitBouyancy;
+	TParamT<f32> mMoveBouyancy;
+	TParamT<f32> mUpDownBrake;
+	TParamT<f32> mCanJumpDepth;
+	TParamT<f32> mEndDepth;
+	TParamT<f32> mFloatHeight;
+	TParamT<f32> mStartVMult;
+	TParamT<f32> mStartVYMult;
+	TParamT<f32> mRush;
+	TParamT<f32> mAnmBrake;
+	TParamT<f32> mPaddleSpeedUp;
+	TParamT<f32> mPaddleJumpUp;
+	TParamT<f32> mFloatUp;
+	TParamT<f32> mWaterLevelCheckHeight;
+	TParamT<f32> mPaddleDown;
+	TParamT<s16> mWaitSinkTime;
+	TParamT<f32> mCanBreathDepth;
+	TParamT<f32> mWaitSinkSpeed;
+	TParamT<f32> mAirDec;
+	TParamT<f32> mAirDecDive;
+	TParamT<f32> mAirInc;
 };
 
 class TMarioParticleParams : public TParams {
 public:
-	TParamT<f32> meltInWaterMax;
-	TParamT<f32> waveEmitSpeed;
-	TParamT<s16> waveAlphaDec;
-	TParamT<f32> bubbleDepth;
-	TParamT<f32> bodyBubbleSpMin;
-	TParamT<f32> bodyBubbleSpMax;
-	TParamT<f32> bodyBubbleEmitMin;
-	TParamT<f32> bodyBubbleEmitMax;
-	TParamT<f32> bubbleToRipple;
-	TParamT<f32> toroccoWind;
-	TParamT<f32> toroccoSpark;
+	TMarioParticleParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mMeltInWaterMax, 0.5f)
+	    , PARAM_INIT(mWaveEmitSpeed, 5.0f)
+	    , PARAM_INIT(mWaveAlphaDec, 5)
+	    , PARAM_INIT(mBubbleDepth, 10.0f)
+	    , PARAM_INIT(mBodyBubbleSpMin, 0.0f)
+	    , PARAM_INIT(mBodyBubbleSpMax, 40.0f)
+	    , PARAM_INIT(mBodyBubbleEmitMin, 0.0f)
+	    , PARAM_INIT(mBodyBubbleEmitMax, 0.5f)
+	    , PARAM_INIT(mBubbleToRipple, 0.3f)
+	    , PARAM_INIT(mToroccoWind, 0.001f)
+	    , PARAM_INIT(mToroccoSpark, 0.001f)
+	{
+	}
+
+	TParamT<f32> mMeltInWaterMax;
+	TParamT<f32> mWaveEmitSpeed;
+	TParamT<s16> mWaveAlphaDec;
+	TParamT<f32> mBubbleDepth;
+	TParamT<f32> mBodyBubbleSpMin;
+	TParamT<f32> mBodyBubbleSpMax;
+	TParamT<f32> mBodyBubbleEmitMin;
+	TParamT<f32> mBodyBubbleEmitMax;
+	TParamT<f32> mBubbleToRipple;
+	TParamT<f32> mToroccoWind;
+	TParamT<f32> mToroccoSpark;
 };
 
 class TSurfingParams : TParams {
 public:
-	TParamT<f32> rotMin;
-	TParamT<f32> rotMax;
-	TParamT<f32> powMin;
-	TParamT<f32> powMax;
-	TParamT<f32> accel;
-	TParamT<f32> waistRoll;
-	TParamT<f32> waistPitch;
-	TParamT<s16> waistRollMax;
-	TParamT<s16> waistPitchMax;
-	TParamT<s32> roll;
-	TParamT<f32> pitch;
-	TParamT<s16> rollMax;
-	TParamT<s16> pitchMax;
-	TParamT<f32> angleChangeRate;
-	TParamT<f32> waistAngleChangeRate;
-	TParamT<f32> scaleMin;
-	TParamT<f32> scaleMax;
-	TParamT<f32> scaleMinSpeed;
-	TParamT<f32> scaleMaxSpeed;
-	TParamT<f32> jumpPow;
-	TParamT<f32> jumpXZRatio;
-	TParamT<f32> clashSpeed;
-	TParamT<s16> clashAngle;
+	TSurfingParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mRotMin, 2048.0f)
+	    , PARAM_INIT(mRotMax, 1024.0f)
+	    , PARAM_INIT(mPowMin, 24.0f)
+	    , PARAM_INIT(mPowMax, 64.0f)
+	    , PARAM_INIT(mAccel, 58.0f)
+	    , PARAM_INIT(mWaistRoll, 0.25f)
+	    , PARAM_INIT(mWaistPitch, 170.0f)
+	    , PARAM_INIT(mWaistRollMax, 0x400)
+	    , PARAM_INIT(mWaistPitchMax, 0x1555)
+	    , PARAM_INIT(mRoll, -0.44999999f)
+	    , PARAM_INIT(mPitch, -170.0f)
+	    , PARAM_INIT(mRollMax, 0x4000)
+	    , PARAM_INIT(mPitchMax, 0x1555)
+	    , PARAM_INIT(mAngleChangeRate, 0.0099999998f)
+	    , PARAM_INIT(mWaistAngleChangeRate, 0.0099999998f)
+	    , PARAM_INIT(mScaleMin, 0.5f)
+	    , PARAM_INIT(mScaleMax, 1.0f)
+	    , PARAM_INIT(mScaleMinSpeed, 24.0f)
+	    , PARAM_INIT(mScaleMaxSpeed, 60.0f)
+	    , PARAM_INIT(mJumpPow, 42.0f)
+	    , PARAM_INIT(mJumpXZRatio, 0.25f)
+	    , PARAM_INIT(mClashSpeed, 40.0f)
+	    , PARAM_INIT(mClashAngle, 0x5555)
+	{
+	}
+
+	TParamT<f32> mRotMin;
+	TParamT<f32> mRotMax;
+	TParamT<f32> mPowMin;
+	TParamT<f32> mPowMax;
+	TParamT<f32> mAccel;
+	TParamT<f32> mWaistRoll;
+	TParamT<f32> mWaistPitch;
+	TParamT<s16> mWaistRollMax;
+	TParamT<s16> mWaistPitchMax;
+	TParamT<s32> mRoll;
+	TParamT<f32> mPitch;
+	TParamT<s16> mRollMax;
+	TParamT<s16> mPitchMax;
+	TParamT<f32> mAngleChangeRate;
+	TParamT<f32> mWaistAngleChangeRate;
+	TParamT<f32> mScaleMin;
+	TParamT<f32> mScaleMax;
+	TParamT<f32> mScaleMinSpeed;
+	TParamT<f32> mScaleMaxSpeed;
+	TParamT<f32> mJumpPow;
+	TParamT<f32> mJumpXZRatio;
+	TParamT<f32> mClashSpeed;
+	TParamT<s16> mClashAngle;
 };
 
 class TControllerParams : TParams {
 public:
-	TParamT<u8> analogLRToZeroVal;
-	TParamT<u8> analogLRToMiddleVal;
-	TParamT<u8> analogLRToMaxVal;
-	TParamT<f32> analogLRMiddleLevel;
-	TParamT<f32> startToWalkLevel;
-	TParamT<s16> stickRotateTime;
-	TParamT<s16> lengthMultTimes;
-	TParamT<f32> lengthMult;
-	TParamT<f32> squatRotMidAnalog;
-	TParamT<f32> squatRotMidValue;
+	TControllerParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mAnalogLRToZeroVal, 0x1e)
+	    , PARAM_INIT(mAnalogLRToMiddleVal, 0x5a)
+	    , PARAM_INIT(mAnalogLRToMaxVal, 0x96)
+	    , PARAM_INIT(mAnalogLRMiddleLevel, 0.1f)
+	    , PARAM_INIT(mStartToWalkLevel, 15.0f)
+	    , PARAM_INIT(mStickRotateTime, 0x18)
+	    , PARAM_INIT(mLengthMultTimes, 10)
+	    , PARAM_INIT(mLengthMult, 0.935f)
+	    , PARAM_INIT(mSquatRotMidAnalog, 0.69999999f)
+	    , PARAM_INIT(mSquatRotMidValue, 0.05f)
+	{
+	}
+
+	TParamT<u8> mAnalogLRToZeroVal;
+	TParamT<u8> mAnalogLRToMiddleVal;
+	TParamT<u8> mAnalogLRToMaxVal;
+	TParamT<f32> mAnalogLRMiddleLevel;
+	TParamT<f32> mStartToWalkLevel;
+	TParamT<s16> mStickRotateTime;
+	TParamT<s16> mLengthMultTimes;
+	TParamT<f32> mLengthMult;
+	TParamT<f32> mSquatRotMidAnalog;
+	TParamT<f32> mSquatRotMidValue;
 };
 
 class TJumpParams : TParams {
 public:
-	TParamT<f32> gravity;
-	TParamT<f32> spinJumpGravity;
-	TParamT<f32> jumpingMax;
-	TParamT<f32> jumpSpeedBrake;
-	TParamT<f32> jumpAccelControl;
-	TParamT<f32> jumpSlideControl;
-	TParamT<f32> turnJumpForce;
-	TParamT<f32> fenceSpeed;
-	TParamT<f32> fireDownForce;
-	TParamT<f32> fireDownControl;
-	TParamT<f32> fireBackVelocity;
-	TParamT<f32> broadJumpForce;
-	TParamT<f32> broadJumpForceY;
-	TParamT<f32> rotateJumpForceY;
-	TParamT<f32> popUpSpeedY;
-	TParamT<f32> popUpSpeedYMult;
-	TParamT<f32> backJumpForce;
-	TParamT<f32> backJumpForceY;
-	TParamT<f32> hipAttackSpeedY;
-	TParamT<f32> superHipAttackSpeedY;
-	TParamT<s16> jumpCatchRotXSp;
-	TParamT<s16> jumpCatchRotXMax;
-	TParamT<f32> rotBroadEnableV;
-	TParamT<f32> rotBroadJumpForce;
-	TParamT<f32> rotBroadJumpForceY;
-	TParamT<f32> trampolineDec;
-	TParamT<f32> secJumpEnableSp;
-	TParamT<f32> secJumpForce;
-	TParamT<f32> secJumpSpeedMult;
-	TParamT<f32> secJumpXZMult;
-	TParamT<f32> triJumpEnableSp;
-	TParamT<f32> ultraJumpForce;
-	TParamT<f32> ultraJumpSpeedMult;
-	TParamT<f32> ultraJumpXZMult;
-	TParamT<f32> valleyDepth;
-	TParamT<f32> thrownAccel;
-	TParamT<f32> thrownSlide;
-	TParamT<f32> thrownBrake;
-	TParamT<f32> tremblePower;
-	TParamT<f32> trembleAccele;
-	TParamT<f32> trembleBrake;
-	TParamT<s16> trembleTime;
-	TParamT<s16> clashAngle;
-	TParamT<f32> jumpJumpCatchSp;
-	TParamT<f32> getOffYoshiY;
-	TParamT<s16> superHipAttackCt;
+	TJumpParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mGravity, 0.8f)
+	    , PARAM_INIT(mSpinJumpGravity, 0.6f)
+	    , PARAM_INIT(mJumpingMax, 80.0f)
+	    , PARAM_INIT(mJumpSpeedBrake, 0.999f)
+	    , PARAM_INIT(mJumpAccelControl, 0.5f)
+	    , PARAM_INIT(mJumpSlideControl, 0.5f)
+	    , PARAM_INIT(mTurnJumpForce, 62.0f)
+	    , PARAM_INIT(mFenceSpeed, 2.0f)
+	    , PARAM_INIT(mFireDownForce, 80.0f)
+	    , PARAM_INIT(mFireDownControl, 1.0f)
+	    , PARAM_INIT(mFireBackVelocity, 1.0f)
+	    , PARAM_INIT(mBroadJumpForce, 80.0f)
+	    , PARAM_INIT(mBroadJumpForceY, 30.0f)
+	    , PARAM_INIT(mRotateJumpForceY, 62.0f)
+	    , PARAM_INIT(mPopUpSpeedY, 5.0f)
+	    , PARAM_INIT(mPopUpSpeedYMult, 10.0f)
+	    , PARAM_INIT(mBackJumpForce, -16.0f)
+	    , PARAM_INIT(mBackJumpForceY, 62.0f)
+	    , PARAM_INIT(mHipAttackSpeedY, -50.0f)
+	    , PARAM_INIT(mSuperHipAttackSpeedY, -80.0f)
+	    , PARAM_INIT(mJumpCatchRotXSp, 0x100)
+	    , PARAM_INIT(mJumpCatchRotXMax, 0x2aaa)
+	    , PARAM_INIT(mRotBroadEnableV, 30.0f)
+	    , PARAM_INIT(mRotBroadJumpForce, 60.0f)
+	    , PARAM_INIT(mRotBroadJumpForceY, 20.0f)
+	    , PARAM_INIT(mTrampolineDec, 1.0f)
+	    , PARAM_INIT(mSecJumpEnableSp, 20.0f)
+	    , PARAM_INIT(mSecJumpForce, 52.0f)
+	    , PARAM_INIT(mSecJumpSpeedMult, 0.0f)
+	    , PARAM_INIT(mSecJumpXZMult, 0.8f)
+	    , PARAM_INIT(mTriJumpEnableSp, 20.0f)
+	    , PARAM_INIT(mUltraJumpForce, 70.0f)
+	    , PARAM_INIT(mUltraJumpSpeedMult, 0.25f)
+	    , PARAM_INIT(mUltraJumpXZMult, 0.8f)
+	    , PARAM_INIT(mValleyDepth, 500.0f)
+	    , PARAM_INIT(mThrownAccel, 0.5f)
+	    , PARAM_INIT(mThrownSlide, 0.5f)
+	    , PARAM_INIT(mThrownBrake, 0.98f)
+	    , PARAM_INIT(mTremblePower, 5.0f)
+	    , PARAM_INIT(mTrembleAccele, 2.0f)
+	    , PARAM_INIT(mTrembleBrake, 0.99f)
+	    , PARAM_INIT(mTrembleTime, 600)
+	    , PARAM_INIT(mClashAngle, 0x3555)
+	    , PARAM_INIT(mJumpJumpCatchSp, 50.0f)
+	    , PARAM_INIT(mGetOffYoshiY, 30.0f)
+	    , PARAM_INIT(mSuperHipAttackCt, 0x32)
+	{
+	}
+
+	TParamT<f32> mGravity;
+	TParamT<f32> mSpinJumpGravity;
+	TParamT<f32> mJumpingMax;
+	TParamT<f32> mJumpSpeedBrake;
+	TParamT<f32> mJumpAccelControl;
+	TParamT<f32> mJumpSlideControl;
+	TParamT<f32> mTurnJumpForce;
+	TParamT<f32> mFenceSpeed;
+	TParamT<f32> mFireDownForce;
+	TParamT<f32> mFireDownControl;
+	TParamT<f32> mFireBackVelocity;
+	TParamT<f32> mBroadJumpForce;
+	TParamT<f32> mBroadJumpForceY;
+	TParamT<f32> mRotateJumpForceY;
+	TParamT<f32> mPopUpSpeedY;
+	TParamT<f32> mPopUpSpeedYMult;
+	TParamT<f32> mBackJumpForce;
+	TParamT<f32> mBackJumpForceY;
+	TParamT<f32> mHipAttackSpeedY;
+	TParamT<f32> mSuperHipAttackSpeedY;
+	TParamT<s16> mJumpCatchRotXSp;
+	TParamT<s16> mJumpCatchRotXMax;
+	TParamT<f32> mRotBroadEnableV;
+	TParamT<f32> mRotBroadJumpForce;
+	TParamT<f32> mRotBroadJumpForceY;
+	TParamT<f32> mTrampolineDec;
+	TParamT<f32> mSecJumpEnableSp;
+	TParamT<f32> mSecJumpForce;
+	TParamT<f32> mSecJumpSpeedMult;
+	TParamT<f32> mSecJumpXZMult;
+	TParamT<f32> mTriJumpEnableSp;
+	TParamT<f32> mUltraJumpForce;
+	TParamT<f32> mUltraJumpSpeedMult;
+	TParamT<f32> mUltraJumpXZMult;
+	TParamT<f32> mValleyDepth;
+	TParamT<f32> mThrownAccel;
+	TParamT<f32> mThrownSlide;
+	TParamT<f32> mThrownBrake;
+	TParamT<f32> mTremblePower;
+	TParamT<f32> mTrembleAccele;
+	TParamT<f32> mTrembleBrake;
+	TParamT<s16> mTrembleTime;
+	TParamT<s16> mClashAngle;
+	TParamT<f32> mJumpJumpCatchSp;
+	TParamT<f32> mGetOffYoshiY;
+	TParamT<s16> mSuperHipAttackCt;
 };
 
 class TRunParams : TParams {
 public:
-	TParamT<f32> maxSpeed;
-	TParamT<f32> velMinusBrake;
-	TParamT<f32> addBase;
-	TParamT<f32> addVelDiv;
-	TParamT<f32> decStartNrmY;
-	TParamT<f32> decBrake;
-	TParamT<f32> soft2Walk;
-	TParamT<f32> walk2Soft;
-	TParamT<f32> softStepAnmMult;
-	TParamT<f32> runAnmSpeedBase;
-	TParamT<f32> runAnmSpeedMult;
-	TParamT<f32> motBlendWalkSp;
-	TParamT<f32> motBlendRunSp;
-	TParamT<f32> swimDepth;
-	TParamT<f32> inWaterBrake;
-	TParamT<f32> inWaterAnmBrake;
-	TParamT<f32> pumpingSlideSp;
-	TParamT<f32> pumpingSlideAnmSp;
-	TParamT<f32> doJumpCatchSp;
-	TParamT<f32> turnNeedSp;
-	TParamT<s16> dashRotSp;
+	TRunParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mMaxSpeed, 32.0f)
+	    , PARAM_INIT(mVelMinusBrake, 1.1f)
+	    , PARAM_INIT(mAddBase, 1.1f)
+	    , PARAM_INIT(mAddVelDiv, 0.023255814f)
+	    , PARAM_INIT(mDecStartNrmY, 0.94999999f)
+	    , PARAM_INIT(mDecBrake, 1.0f)
+	    , PARAM_INIT(mSoft2Walk, 8.0f)
+	    , PARAM_INIT(mWalk2Soft, 5.0f)
+	    , PARAM_INIT(mSoftStepAnmMult, 0.125f)
+	    , PARAM_INIT(mRunAnmSpeedBase, 1.0f)
+	    , PARAM_INIT(mRunAnmSpeedMult, 0.059999999f)
+	    , PARAM_INIT(mMotBlendWalkSp, 1.0f)
+	    , PARAM_INIT(mMotBlendRunSp, 3.0f)
+	    , PARAM_INIT(mSwimDepth, 120.0f)
+	    , PARAM_INIT(mInWaterBrake, 0.89999998f)
+	    , PARAM_INIT(mInWaterAnmBrake, 0.6f)
+	    , PARAM_INIT(mPumpingSlideSp, 0.1f)
+	    , PARAM_INIT(mPumpingSlideAnmSp, 0.5f)
+	    , PARAM_INIT(mDoJumpCatchSp, 15.0f)
+	    , PARAM_INIT(mTurnNeedSp, 10.0f)
+	    , PARAM_INIT(mDashRotSp, 100)
+	{
+	}
+
+	TParamT<f32> mMaxSpeed;
+	TParamT<f32> mVelMinusBrake;
+	TParamT<f32> mAddBase;
+	TParamT<f32> mAddVelDiv;
+	TParamT<f32> mDecStartNrmY;
+	TParamT<f32> mDecBrake;
+	TParamT<f32> mSoft2Walk;
+	TParamT<f32> mWalk2Soft;
+	TParamT<f32> mSoftStepAnmMult;
+	TParamT<f32> mRunAnmSpeedBase;
+	TParamT<f32> mRunAnmSpeedMult;
+	TParamT<f32> mMotBlendWalkSp;
+	TParamT<f32> mMotBlendRunSp;
+	TParamT<f32> mSwimDepth;
+	TParamT<f32> mInWaterBrake;
+	TParamT<f32> mInWaterAnmBrake;
+	TParamT<f32> mPumpingSlideSp;
+	TParamT<f32> mPumpingSlideAnmSp;
+	TParamT<f32> mDoJumpCatchSp;
+	TParamT<f32> mTurnNeedSp;
+	TParamT<s16> mDashRotSp;
 };
 
 class TGraffitoParams : TParams {
 public:
-	TParamT<s16> sinkTime;
-	TParamT<s16> sinkDmgTime;
-	TParamT<f32> sinkHeight;
-	TParamT<f32> sinkMoveMin;
-	TParamT<f32> sinkMoveMax;
-	TParamT<f32> sinkRecover;
-	TParamT<f32> sinkJumpRateMin;
-	TParamT<f32> sinkJumpRateMax;
-	TParamT<f32> sinkPumpLimit;
-	TParamT<f32> field14_0xbc;
-	TParamT<f32> fireHeight;
-	TParamT<s16> dizzySlipCtMax;
-	TParamT<s16> dizzyWalkCtMax;
-	TParamT<s16> dizzyAngleY;
-	TParamT<f32> dizzyAngleRate;
-	TParamT<f32> dizzyPowerRate;
-	TParamT<f32> dizzyPower;
-	TParamT<s16> fireInvincibleTime;
-	TParamT<s16> footEraseTimes;
-	TParamT<f32> footEraseSize;
-	TParamT<f32> footEraseFront;
+	TGraffitoParams(const char* prm)
+	    : TParams(prm)
+	    , PARAM_INIT(mSinkTime, 0xf0)
+	    , PARAM_INIT(mSinkDmgTime, 0xf0)
+	    , PARAM_INIT(mSinkHeight, 150.0f)
+	    , PARAM_INIT(mSinkMoveMin, 0.3f)
+	    , PARAM_INIT(mSinkMoveMax, 0.5f)
+	    , PARAM_INIT(mSinkRecover, 0.05f)
+	    , PARAM_INIT(mSinkJumpRateMin, 0.1f)
+	    , PARAM_INIT(mSinkJumpRateMax, 0.3f)
+	    , PARAM_INIT(mSinkPumpLimit, 0.25f)
+	    , PARAM_INIT(mSinkDmgDepth, 0.25f)
+	    , PARAM_INIT(mFireHeight, 1000.0f)
+	    , PARAM_INIT(mDizzySlipCtMax, 1000)
+	    , PARAM_INIT(mDizzyWalkCtMax, 1000)
+	    , PARAM_INIT(mDizzyAngleY, 0x7fff)
+	    , PARAM_INIT(mDizzyAngleRate, 400.0f)
+	    , PARAM_INIT(mDizzyPowerRate, 120.0f)
+	    , PARAM_INIT(mDizzyPower, 20.0f)
+	    , PARAM_INIT(mFireInvincibleTime, 0x96)
+	    , PARAM_INIT(mFootEraseTimes, 4)
+	    , PARAM_INIT(mFootEraseSize, 400.0f)
+	    , PARAM_INIT(mFootEraseFront, 200.0f)
+	{
+	}
+
+	TParamT<s16> mSinkTime;
+	TParamT<s16> mSinkDmgTime;
+	TParamT<f32> mSinkHeight;
+	TParamT<f32> mSinkMoveMin;
+	TParamT<f32> mSinkMoveMax;
+	TParamT<f32> mSinkRecover;
+	TParamT<f32> mSinkJumpRateMin;
+	TParamT<f32> mSinkJumpRateMax;
+	TParamT<f32> mSinkPumpLimit;
+	TParamT<f32> mSinkDmgDepth;
+	TParamT<f32> mFireHeight;
+	TParamT<s16> mDizzySlipCtMax;
+	TParamT<s16> mDizzyWalkCtMax;
+	TParamT<s16> mDizzyAngleY;
+	TParamT<f32> mDizzyAngleRate;
+	TParamT<f32> mDizzyPowerRate;
+	TParamT<f32> mDizzyPower;
+	TParamT<s16> mFireInvincibleTime;
+	TParamT<s16> mFootEraseTimes;
+	TParamT<f32> mFootEraseSize;
+	TParamT<f32> mFootEraseFront;
 };
 
 #endif

--- a/include/System/BaseParam.hpp
+++ b/include/System/BaseParam.hpp
@@ -8,7 +8,7 @@ class TParams;
 class TBaseParam {
 public:
 	TBaseParam(TParams* params, unsigned short code, const char* paramName);
-	virtual inline void load(JSUMemoryInputStream&);
+	virtual void load(JSUMemoryInputStream&) { }
 
 	u16 keyCode;
 	const char* name;

--- a/include/System/BaseParam.hpp
+++ b/include/System/BaseParam.hpp
@@ -3,12 +3,15 @@
 
 #include <JSystem/JSupport/JSUMemoryInputStream.hpp>
 
+class TParams;
+
 class TBaseParam {
 public:
-	virtual void load(JSUMemoryInputStream&);
+	TBaseParam(TParams* params, unsigned short code, const char* paramName);
+	virtual inline void load(JSUMemoryInputStream&);
 
 	u16 keyCode;
-	char* name;
+	const char* name;
 	TBaseParam* next;
 };
 

--- a/include/System/ParamInst.hpp
+++ b/include/System/ParamInst.hpp
@@ -1,8 +1,8 @@
 #ifndef PARAM_INST_HPP
 #define PARAM_INST_HPP
 
-#include "JSystem/JDrama/JDRNameRef.hpp"
-#include "System/BaseParam.hpp"
+#include <JSystem/JDrama/JDRNameRef.hpp>
+#include <System/BaseParam.hpp>
 
 #define PARAM_INIT(member, value)                                              \
 	member(this, JDrama::TNameRef::calcKeyCode("#member"), "#member", value)
@@ -16,7 +16,9 @@ public:
 	{
 	}
 
-	void load(JSUMemoryInputStream& stream);
+	virtual void load(JSUMemoryInputStream& stream);
+
+	// fabricated
 	T get() const { return value; }
 
 	T value;

--- a/include/System/ParamInst.hpp
+++ b/include/System/ParamInst.hpp
@@ -5,9 +5,27 @@
 
 template <typename T> class TParamT : public TBaseParam {
 public:
+	TParamT(TParams* params, unsigned short code, const char* paramName,
+	        T defaultValue)
+	    : TBaseParam(params, code, paramName)
+	    , value(defaultValue)
+	{
+	}
+
 	void load(JSUMemoryInputStream& stream);
+	T get() const { return value; }
 
 	T value;
+};
+
+template <typename T> class TParamRT : public TParamT<T> {
+public:
+	TParamRT(TParams* parent, u16 keycode, const char* name, T defaultValue)
+	    : TParamT<T>(parent, keycode, name, defaultValue)
+	{
+	}
+
+	inline void set(T param) {};
 };
 
 #endif

--- a/include/System/ParamInst.hpp
+++ b/include/System/ParamInst.hpp
@@ -1,7 +1,11 @@
 #ifndef PARAM_INST_HPP
 #define PARAM_INST_HPP
 
+#include "JSystem/JDrama/JDRNameRef.hpp"
 #include "System/BaseParam.hpp"
+
+#define PARAM_INIT(member, value)                                              \
+	member(this, JDrama::TNameRef::calcKeyCode("#member"), "#member", value)
 
 template <typename T> class TParamT : public TBaseParam {
 public:

--- a/include/System/Params.hpp
+++ b/include/System/Params.hpp
@@ -1,0 +1,33 @@
+#ifndef PARAMS_HPP
+#define PARAMS_HPP
+
+#include <System/BaseParam.hpp>
+
+#include <JSystem/JKernel/JKRFileLoader.hpp>
+class TParams {
+public:
+	TParams()
+	    : mPrmPath(nullptr)
+	    , mHead(nullptr)
+	{
+	}
+	TParams(const char* prm)
+	    : mPrmPath(prm)
+	    , mHead(nullptr)
+	{
+	}
+	~TParams() { }
+
+	static void finalize();
+
+	bool load(const char* filename);
+	void load(JSUMemoryInputStream& stream);
+	void init();
+
+	const char* mPrmPath;
+	TBaseParam* mHead;
+	static JKRFileLoader* mArc;
+	static JKRFileLoader* mSceneArc;
+};
+
+#endif

--- a/include/System/Params.hpp
+++ b/include/System/Params.hpp
@@ -4,6 +4,7 @@
 #include <System/BaseParam.hpp>
 
 #include <JSystem/JKernel/JKRFileLoader.hpp>
+
 class TParams {
 public:
 	TParams()

--- a/src/JSystem/J2D/J2DScreen.cpp
+++ b/src/JSystem/J2D/J2DScreen.cpp
@@ -176,6 +176,8 @@ J2DSetScreen::J2DSetScreen(const char* name, JKRArchive* arch)
 	u8* res = (u8*)JKRGetNameResource(name, arch);
 	if (res) {
 		u32 sz = JKRFileLoader::getResSize(res, nullptr);
+		// Probably an assert
+		(void)!res;
 		JSUMemoryInputStream stream(res, sz);
 		makeHiearachyPanes(this, &stream, false, true, false, nullptr);
 	}

--- a/src/Player/MarioAccess.cpp
+++ b/src/Player/MarioAccess.cpp
@@ -206,7 +206,7 @@ void* SMS_GetMarioWaterGun()
 	return gpMarioOriginal->waterGun;
 }
 
-f32 SMS_GetMarioGravity() { return gpMarioOriginal->jumpParams.gravity.value; }
+f32 SMS_GetMarioGravity() { return gpMarioOriginal->jumpParams.mGravity.value; }
 
 f32 SMS_GetMarioGrLevel() { return gpMarioOriginal->floorPosition.y; }
 
@@ -304,6 +304,6 @@ void SMS_SetMarioAccessParams()
 	gpMarioLightID = &gpMarioOriginal->lightID;
 	gpMarioFlag    = &gpMarioOriginal->_118;
 
-	gpMarioThrowPower  = &gpMarioOriginal->deParams.throwPower.value;
+	gpMarioThrowPower  = &gpMarioOriginal->deParams.mThrowPower.value;
 	gpMarioGroundPlane = &gpMarioOriginal->floor;
 }

--- a/src/System/BaseParam.cpp
+++ b/src/System/BaseParam.cpp
@@ -1,0 +1,23 @@
+#include "System/BaseParam.hpp"
+#include "System/Params.hpp"
+
+TBaseParam::TBaseParam(TParams* params, unsigned short code,
+                       const char* paramName)
+    : keyCode(code)
+    , name(paramName)
+    , next(nullptr)
+{
+	TBaseParam* root = params->mHead;
+	if (root != nullptr) {
+		TBaseParam* param = root;
+		while (param->next != nullptr) {
+			param = param->next;
+		}
+		param->next = this;
+		return;
+	}
+
+	params->mHead = this;
+}
+
+void TBaseParam::load(JSUMemoryInputStream& stream) { }

--- a/src/System/BaseParam.cpp
+++ b/src/System/BaseParam.cpp
@@ -19,5 +19,3 @@ TBaseParam::TBaseParam(TParams* params, unsigned short code,
 
 	params->mHead = this;
 }
-
-void TBaseParam::load(JSUMemoryInputStream& stream) { }

--- a/src/System/Params.cpp
+++ b/src/System/Params.cpp
@@ -1,6 +1,11 @@
 #include <System/Params.hpp>
 #include <JSystem/JSupport/JSUMemoryInputStream.hpp>
 
+static const char SSceneParamsDir[] = "/map/params";
+
+JKRFileLoader* TParams::mArc      = nullptr;
+JKRFileLoader* TParams::mSceneArc = nullptr;
+
 bool TParams::load(const char* filename)
 {
 	bool found = false;
@@ -9,7 +14,7 @@ bool TParams::load(const char* filename)
 	}
 
 	void* resource = nullptr;
-	if (mSceneArc != nullptr && mSceneArc->becomeCurrent("/map/params")) {
+	if (mSceneArc != nullptr && mSceneArc->becomeCurrent(SSceneParamsDir)) {
 		resource = mSceneArc->getResource(filename);
 	}
 
@@ -32,6 +37,18 @@ bool TParams::load(const char* filename)
 	}
 
 	return found;
+}
+
+void TParams::finalize()
+{
+	mArc      = nullptr;
+	mSceneArc = nullptr;
+}
+
+void TParams::init()
+{
+	mArc      = JKRFileLoader::getVolume("params");
+	mSceneArc = JKRFileLoader::getVolume("scene");
 }
 
 void TParams::load(JSUMemoryInputStream& stream)
@@ -57,18 +74,3 @@ void TParams::load(JSUMemoryInputStream& stream)
 		}
 	}
 }
-
-void TParams::init()
-{
-	mArc      = JKRFileLoader::getVolume("params");
-	mSceneArc = JKRFileLoader::getVolume("scene");
-}
-
-void TParams::finalize()
-{
-	mArc      = nullptr;
-	mSceneArc = nullptr;
-}
-
-JKRFileLoader* TParams::mArc      = nullptr;
-JKRFileLoader* TParams::mSceneArc = nullptr;

--- a/src/System/Params.cpp
+++ b/src/System/Params.cpp
@@ -1,0 +1,74 @@
+#include <System/Params.hpp>
+#include <JSystem/JSupport/JSUMemoryInputStream.hpp>
+
+bool TParams::load(const char* filename)
+{
+	bool found = false;
+	if (filename[0] == '/') {
+		filename++;
+	}
+
+	void* resource = nullptr;
+	if (mSceneArc != nullptr && mSceneArc->becomeCurrent("/map/params")) {
+		resource = mSceneArc->getResource(filename);
+	}
+
+	if (resource != nullptr) {
+		s32 size = mSceneArc->getResSize(resource);
+		JSUMemoryInputStream stream(resource, size);
+		load(stream);
+		found = true;
+	} else {
+		if (mArc != nullptr) {
+			mArc->becomeCurrent("/");
+			void* resource2 = mArc->getResource(filename);
+			if (resource2 != nullptr) {
+				s32 size = mArc->getResSize(resource2);
+				JSUMemoryInputStream stream(resource2, size);
+				load(stream);
+				found = true;
+			}
+		}
+	}
+
+	return found;
+}
+
+void TParams::load(JSUMemoryInputStream& stream)
+{
+	if (this->mHead != nullptr) {
+		s32 length = stream.readS32();
+		for (int i = 0; i < length; i++) {
+			u16 keyCode = stream.read16b();
+			char buffer[0x50];
+			stream.readString(buffer, 0x50);
+
+			TBaseParam* param;
+			for (param = this->mHead; param != nullptr; param = param->next) {
+				if (keyCode == param->keyCode && !strcmp(buffer, param->name)) {
+					param->load(stream);
+					break;
+				}
+			}
+			if (param == nullptr) {
+				s32 end = stream.read32b();
+				stream.skip(end);
+			}
+		}
+	}
+}
+
+void TParams::init()
+{
+	mArc      = JKRFileLoader::getVolume("params");
+	mSceneArc = JKRFileLoader::getVolume("scene");
+}
+
+void TParams::finalize()
+{
+	mArc      = nullptr;
+	mSceneArc = nullptr;
+}
+
+JKRFileLoader* TParams::mArc      = nullptr;
+JKRFileLoader* TParams::mSceneArc = nullptr;


### PR DESCRIPTION
Also updates MarioInit to use new param macro + initialize with proper values.

I could not make TParams::load match 100%, i could not figure out how to make it evaluate to mr r4, r31 instead of addi r4, r31, 0x0. I think the operations are basically equivalent though.
I also couldn't quite figure out how to create a named field in .rodata... It currently is evaluated to @49.