### PR TITLE
Decompile THPRender

### DIFF
--- a/include/System/THPRender.hpp
+++ b/include/System/THPRender.hpp
@@ -1,0 +1,24 @@
+#ifndef SYSTEM_THP_RENDER_HPP
+#define SYSTEM_THP_RENDER_HPP
+
+#include <JSystem/JDrama/JDRViewObj.hpp>
+#include <JSystem/JDrama/JDRGraphics.hpp>
+#include "dolphin/gx/GXTransform.h"
+
+#include "MarioUtil/DrawUtil.hpp"
+#include "THPPlayer/THPPlayer.h"
+
+class TTHPRender : public JDrama::TViewObj {
+public:
+	virtual ~TTHPRender() {}
+	void perform(u32, JDrama::TGraphics*); /* override */
+	TTHPRender(const char* name);
+
+	/* 0x10 */ u32 x;
+	/* 0x14 */ u32 y;
+	/* 0x18 */ u32 polyW;
+	/* 0x1c */ u32 polyH;
+	/* 0x20 */ u32 unk10;
+};
+
+#endif // SYSTEM_THP_RENDER_HPP

--- a/include/System/THPRender.hpp
+++ b/include/System/THPRender.hpp
@@ -18,7 +18,7 @@ public:
 	/* 0x14 */ u32 y;
 	/* 0x18 */ u32 polyW;
 	/* 0x1c */ u32 polyH;
-	/* 0x20 */ u32 unk10;
+	/* 0x20 */ u32 frameNumber;
 };
 
 #endif // SYSTEM_THP_RENDER_HPP

--- a/include/System/THPRender.hpp
+++ b/include/System/THPRender.hpp
@@ -3,14 +3,13 @@
 
 #include <JSystem/JDrama/JDRViewObj.hpp>
 #include <JSystem/JDrama/JDRGraphics.hpp>
-#include "dolphin/gx/GXTransform.h"
+#include <dolphin/gx/GXTransform.h>
 
-#include "MarioUtil/DrawUtil.hpp"
-#include "THPPlayer/THPPlayer.h"
+#include <MarioUtil/DrawUtil.hpp>
+#include <THPPlayer/THPPlayer.h>
 
 class TTHPRender : public JDrama::TViewObj {
 public:
-	virtual ~TTHPRender() { }
 	void perform(u32, JDrama::TGraphics*); /* override */
 	TTHPRender(const char* name);
 

--- a/include/System/THPRender.hpp
+++ b/include/System/THPRender.hpp
@@ -10,7 +10,7 @@
 
 class TTHPRender : public JDrama::TViewObj {
 public:
-	virtual ~TTHPRender() {}
+	virtual ~TTHPRender() { }
 	void perform(u32, JDrama::TGraphics*); /* override */
 	TTHPRender(const char* name);
 

--- a/include/System/THPRender.hpp
+++ b/include/System/THPRender.hpp
@@ -10,7 +10,7 @@
 
 class TTHPRender : public JDrama::TViewObj {
 public:
-	void perform(u32, JDrama::TGraphics*); /* override */
+	virtual void perform(u32, JDrama::TGraphics*); /* override */
 	TTHPRender(const char* name);
 
 	/* 0x10 */ u32 x;

--- a/src/System/THPRender.cpp
+++ b/src/System/THPRender.cpp
@@ -7,7 +7,7 @@ void TTHPRender::perform(u32 flags, JDrama::TGraphics* gfx)
 		SMS_DrawInit();
 		GXLoadPosMtxImm(gfx->unkB4, GX_PNMTX0);
 		GXSetCurrentMtx(GX_PNMTX0);
-		this->unk10 = THPPlayerDrawCurrentFrame(0, this->x, this->y,
+		this->frameNumber = THPPlayerDrawCurrentFrame(0, this->x, this->y,
 		                                        this->polyW, this->polyH);
 	}
 }
@@ -15,5 +15,5 @@ TTHPRender::TTHPRender(const char* name) : JDrama::TViewObj(name)
 {
 	this->x     = 0;
 	this->y     = 0;
-	this->unk10 = -1;
+	this->frameNumber = -1;
 }

--- a/src/System/THPRender.cpp
+++ b/src/System/THPRender.cpp
@@ -1,0 +1,19 @@
+#include "System/THPRender.hpp"
+
+void TTHPRender::perform(u32 flags, JDrama::TGraphics* gfx)
+{
+	if ((flags & 8)) {
+
+		SMS_DrawInit();
+		GXLoadPosMtxImm(gfx->unkB4, GX_PNMTX0);
+		GXSetCurrentMtx(GX_PNMTX0);
+		this->unk10 = THPPlayerDrawCurrentFrame(0, this->x, this->y,
+		                                        this->polyW, this->polyH);
+	}
+}
+TTHPRender::TTHPRender(const char* name) : JDrama::TViewObj(name)
+{
+	this->x     = 0;
+	this->y     = 0;
+	this->unk10 = -1;
+}

--- a/src/System/THPRender.cpp
+++ b/src/System/THPRender.cpp
@@ -8,12 +8,13 @@ void TTHPRender::perform(u32 flags, JDrama::TGraphics* gfx)
 		GXLoadPosMtxImm(gfx->unkB4, GX_PNMTX0);
 		GXSetCurrentMtx(GX_PNMTX0);
 		this->frameNumber = THPPlayerDrawCurrentFrame(0, this->x, this->y,
-		                                        this->polyW, this->polyH);
+		                                              this->polyW, this->polyH);
 	}
 }
-TTHPRender::TTHPRender(const char* name) : JDrama::TViewObj(name)
+TTHPRender::TTHPRender(const char* name)
+    : JDrama::TViewObj(name)
 {
-	this->x     = 0;
-	this->y     = 0;
+	this->x           = 0;
+	this->y           = 0;
 	this->frameNumber = -1;
 }

--- a/src/System/THPRender.cpp
+++ b/src/System/THPRender.cpp
@@ -1,4 +1,4 @@
-#include "System/THPRender.hpp"
+#include <System/THPRender.hpp>
 
 void TTHPRender::perform(u32 flags, JDrama::TGraphics* gfx)
 {
@@ -7,14 +7,14 @@ void TTHPRender::perform(u32 flags, JDrama::TGraphics* gfx)
 		SMS_DrawInit();
 		GXLoadPosMtxImm(gfx->unkB4, GX_PNMTX0);
 		GXSetCurrentMtx(GX_PNMTX0);
-		this->frameNumber = THPPlayerDrawCurrentFrame(0, this->x, this->y,
-		                                              this->polyW, this->polyH);
+		frameNumber = THPPlayerDrawCurrentFrame(0, x, y, polyW, polyH);
 	}
 }
+
 TTHPRender::TTHPRender(const char* name)
     : JDrama::TViewObj(name)
 {
-	this->x           = 0;
-	this->y           = 0;
-	this->frameNumber = -1;
+	x           = 0;
+	y           = 0;
+	frameNumber = -1;
 }


### PR DESCRIPTION
Gets a 100% match, however `JDrama::TViewObj`'s vtable and destructor end up getting defined in this TU, polluting the `.data-0` section (thus also fails to match as a result). Otherwise it's a 100% match.