### PR TITLE
Fix command to unquarantine Wine Crossover.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ macOS
 After OS upgrades, if macOS complains about `Wine Crossover.app` being unverified, you can unquarantine it using:
 
 ```sh
-sudo xattr -rd com.apple.quarantine '/Applications/Wine Crossover.app'
+sudo xattr -d com.apple.quarantine '/Applications/Wine Crossover.app'
 ```
 
 Linux


### PR DESCRIPTION
the -r flag in the `xattr` command is not always supported, and inadvisable in a template command