### PR TITLE
First pass at wireBinder TU

### DIFF
--- a/include/Enemy/WireBinder.hpp
+++ b/include/Enemy/WireBinder.hpp
@@ -1,0 +1,27 @@
+#ifndef ENEMY_WIRE_BINDER_HPP
+#define ENEMY_WIRE_BINDER_HPP
+
+#include <JSystem/JGeometry.hpp>
+#include <Strategic/Binder.hpp>
+#include <Strategic/LiveActor.hpp>
+
+class TWireBinder : TBinder {
+public:
+    bool init(const JGeometry::TVec3<f32>&);
+    void bind(TLiveActor*);
+    JGeometry::TVec3<f32> getDir() const { return mDir; }
+    JGeometry::TVec3<f32> getDirAtPos(const JGeometry::TVec3<f32>&, f32) const;
+    void getPoint(JGeometry::TVec3<f32>*, f32) const;
+    void getPoint(JGeometry::TVec3<f32>*, const JGeometry::TVec3<f32>&) const;
+    bool isEndWire(const JGeometry::TVec3<float>&, float) const;
+
+    static bool isOnWire(const JGeometry::TVec3<f32>&);
+
+    ~TWireBinder();
+
+private:
+    /* 0x04 */ u32 mWireNumber;
+    /* 0x08 */ JGeometry::TVec3<f32> mDir;
+};
+
+#endif

--- a/include/Enemy/WireBinder.hpp
+++ b/include/Enemy/WireBinder.hpp
@@ -7,21 +7,21 @@
 
 class TWireBinder : TBinder {
 public:
-    bool init(const JGeometry::TVec3<f32>&);
-    void bind(TLiveActor*);
-    JGeometry::TVec3<f32> getDir() const { return mDir; }
-    JGeometry::TVec3<f32> getDirAtPos(const JGeometry::TVec3<f32>&, f32) const;
-    void getPoint(JGeometry::TVec3<f32>*, f32) const;
-    void getPoint(JGeometry::TVec3<f32>*, const JGeometry::TVec3<f32>&) const;
-    bool isEndWire(const JGeometry::TVec3<float>&, float) const;
+	bool init(const JGeometry::TVec3<f32>&);
+	void bind(TLiveActor*);
+	JGeometry::TVec3<f32> getDir() const { return mDir; }
+	JGeometry::TVec3<f32> getDirAtPos(const JGeometry::TVec3<f32>&, f32) const;
+	void getPoint(JGeometry::TVec3<f32>*, f32) const;
+	void getPoint(JGeometry::TVec3<f32>*, const JGeometry::TVec3<f32>&) const;
+	bool isEndWire(const JGeometry::TVec3<float>&, float) const;
 
-    static bool isOnWire(const JGeometry::TVec3<f32>&);
+	static bool isOnWire(const JGeometry::TVec3<f32>&);
 
-    ~TWireBinder();
+	~TWireBinder();
 
 private:
-    /* 0x04 */ u32 mWireNumber;
-    /* 0x08 */ JGeometry::TVec3<f32> mDir;
+	/* 0x04 */ u32 mWireNumber;
+	/* 0x08 */ JGeometry::TVec3<f32> mDir;
 };
 
 #endif

--- a/include/Map/MapWire.hpp
+++ b/include/Map/MapWire.hpp
@@ -36,6 +36,9 @@ public:
 	static f32 mDrawWidth;
 	static f32 mDrawHeight;
 
+	const JGeometry::TVec3<f32>& getUnk00() const { return unk00; }
+	const JGeometry::TVec3<f32>& getUnk0C() const { return unk0C; }
+
 public:
 	/* 0x00 */ JGeometry::TVec3<f32> unk00; // start point???
 	/* 0x0C */ JGeometry::TVec3<f32> unk0C; // end point???

--- a/include/Map/MapWire.hpp
+++ b/include/Map/MapWire.hpp
@@ -35,6 +35,35 @@ public:
 
 	static f32 mDrawWidth;
 	static f32 mDrawHeight;
+
+public:
+	/* 0x00 */ JGeometry::TVec3<f32> unk00; // start point???
+	/* 0x0C */ JGeometry::TVec3<f32> unk0C; // end point???
+	/* 0x18 */ JGeometry::TVec3<f32> unk18;
+	/* 0x24 */ f32 unk24;
+	/* 0x28 */ f32 unk28;
+	/* 0x2C */ f32 unk2C;
+	/* 0x30 */ f32 unk30;
+	/* 0x34 */ f32 unk34;
+	/* 0x38 */ f32 unk38;
+	/* 0x3C */ void** unk3C; // Unknown type for now
+	/* 0x40 */ void** unk40; // Unknown type for now
+	/* 0x44 */ u16 unk44;
+	/* 0x46 */ u16 unk46;
+	/* 0x48 */ u32 unk48;
+	/* 0x4C */ f32 unk4C;
+	/* 0x50 */ f32 unk50;
+	/* 0x54 */ f32 unk54;
+	/* 0x58 */ f32 unk58;
+	/* 0x5C */ f32 unk5C;
+	/* 0x60 */ f32 unk60;
+	/* 0x64 */ f32 unk64;
+	/* 0x68 */ f32 unk68;
+	/* 0x6C */ f32 unk6C;
+	/* 0x70 */ f32 unk70;
+	/* 0x74 */ f32 unk74;
+	/* 0x78 */ f32 unk78;
+	/* 0x7C */ u16 unk7C;
 };
 
 #endif

--- a/include/Map/MapWireManager.hpp
+++ b/include/Map/MapWireManager.hpp
@@ -63,13 +63,9 @@ public:
 	static JUtility::TColor mLowerSurface;
 
 	// fabricated
-	f32 getPosInWire(int idx, const JGeometry::TVec3<f32>& pos)
+	static TMapWire* getGlobalWire(int index)
 	{
-		return unk18[idx]->getPosInWire(pos);
-	}
-	void getPointPosOnWire(int idx, f32 pos, JGeometry::TVec3<f32>& out)
-	{
-		unk18[idx]->getPointPosOnWire(pos, &out);
+		return gpMapWireManager->unk18[index];
 	}
 
 public:

--- a/include/Map/MapWireManager.hpp
+++ b/include/Map/MapWireManager.hpp
@@ -62,6 +62,16 @@ public:
 	static JUtility::TColor mUpperSurface;
 	static JUtility::TColor mLowerSurface;
 
+	// fabricated
+	f32 getPosInWire(int idx, const JGeometry::TVec3<f32>& pos)
+	{
+		return unk18[idx]->getPosInWire(pos);
+	}
+	void getPointPosOnWire(int idx, f32 pos, JGeometry::TVec3<f32>& out)
+	{
+		unk18[idx]->getPointPosOnWire(pos, &out);
+	}
+
 public:
 	/* 0x10 */ int unk10;
 	/* 0x14 */ u32 unk14;

--- a/include/Map/MapWireManager.hpp
+++ b/include/Map/MapWireManager.hpp
@@ -47,6 +47,7 @@ TMapWireManager* gpMapWireManager;
 
 class TMapWireManager : public JDrama::TViewObj {
 public:
+	TMapWire* getWire(int index) const;
 	u32 getWireNo(const JGeometry::TVec3<f32>&) const;
 	void getPointPosInNthWire(int, const JGeometry::TVec3<f32>&,
 	                          JGeometry::TVec3<f32>*) const;

--- a/include/Strategic/LiveActor.hpp
+++ b/include/Strategic/LiveActor.hpp
@@ -105,8 +105,22 @@ public:
 	{
 		return mMapCollisionManager;
 	}
+	void getNextFramePosition(JGeometry::TVec3<f32>& result)
+	{
+		result = mPosition;
+		result.add(mLinearVelocity);
+		// It's not clear why we copy mVelocity to a local variable first,
+		// but it matches what TWireBinder::bind does.
+		// We can revisit later if needed.
+		JGeometry::TVec3<f32> velocity = mVelocity;
+		result.add(velocity);
+	}
 	const JGeometry::TVec3<f32>& getVelocity() const { return mVelocity; }
 	void setVelocity(const JGeometry::TVec3<f32>& v) { mVelocity = v; }
+	void setLinearVelocity(const JGeometry::TVec3<f32>& v)
+	{
+		mLinearVelocity = v;
+	}
 
 public:
 	/* 0x70 */ TLiveManager* mManager;

--- a/src/Enemy/wireBinder.cpp
+++ b/src/Enemy/wireBinder.cpp
@@ -4,125 +4,125 @@
 
 bool TWireBinder::init(const JGeometry::TVec3<f32>& param_1)
 {
-    JGeometry::TVec3<f32> local24;
-    JGeometry::TVec3<f32> local30;
+	JGeometry::TVec3<f32> local24;
+	JGeometry::TVec3<f32> local30;
 
-    mWireNumber = gpMapWireManager->getWireNo(param_1);
-    if ((s32)mWireNumber == -1) {
-        return false;
-    }
+	mWireNumber = gpMapWireManager->getWireNo(param_1);
+	if ((s32)mWireNumber == -1) {
+		return false;
+	}
 
-    TMapWire* wire = gpMapWireManager->unk18[mWireNumber];
+	TMapWire* wire = gpMapWireManager->unk18[mWireNumber];
 
-    local24 = wire->unk00;
-    local30 = wire->unk0C;
-    local30.sub(local24);
+	local24 = wire->unk00;
+	local30 = wire->unk0C;
+	local30.sub(local24);
 
-    // TODO: Why does the compiler inline stuff here but not in the target?
-    // See also: TMapObjPlane::calcNrm, TBGAttackHit::perform, etc.
-    mDir.setLength(local30, 1.0f);
-    return true;
+	// TODO: Why does the compiler inline stuff here but not in the target?
+	// See also: TMapObjPlane::calcNrm, TBGAttackHit::perform, etc.
+	mDir.setLength(local30, 1.0f);
+	return true;
 }
 
 void TWireBinder::bind(TLiveActor* actor)
 {
-    
-    JGeometry::TVec3<f32> unk_14 = actor->mPosition;
-    JGeometry::TVec3<f32> unk_20;
-    
-    unk_14.x += actor->mLinearVelocity.x;
-    unk_14.y += actor->mLinearVelocity.y;
-    unk_14.z += actor->mLinearVelocity.z;
-    
-    JGeometry::TVec3<f32> velocity = actor->mVelocity;
-    
-    unk_14.x += velocity.x;
-    unk_14.y += velocity.y;
-    unk_14.z += velocity.z;
-    
-    TMapWire* wire = gpMapWireManager->getWire(mWireNumber);
-    f32 posInWire = wire->getPosInWire(unk_14);
-    gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(posInWire, &unk_20);
+	JGeometry::TVec3<f32> unk_14 = actor->mPosition;
+	JGeometry::TVec3<f32> unk_20;
 
-    // TODO: Investigate this further
-    // The stack addresses used for the isnan checks are off by 0x10,
-    // regardless of whether this is before or after the isnan checks.
-    // However, this padding does align everything else above here.
-    u8 padding[0x10]; // to match allocated stack size
+	unk_14.x += actor->mLinearVelocity.x;
+	unk_14.y += actor->mLinearVelocity.y;
+	unk_14.z += actor->mLinearVelocity.z;
 
-    if (isnan(unk_20.x) || isnan(unk_20.y) || isnan(unk_20.z)) {
-        unk_20.set(actor->mPosition);
-    }
-    
-    f32 fVar = 0.05f + unk_20.y;
-    
-    if (unk_14.y <= fVar) {
-        actor->mLiveFlag &= ~LIVE_FLAG_AIRBORNE;
-    } else {
-        actor->mLiveFlag |= LIVE_FLAG_AIRBORNE;
-    }
-    
-    actor->mLinearVelocity = unk_20 - actor->mPosition;
+	JGeometry::TVec3<f32> velocity = actor->mVelocity;
+
+	unk_14.x += velocity.x;
+	unk_14.y += velocity.y;
+	unk_14.z += velocity.z;
+
+	TMapWire* wire = gpMapWireManager->getWire(mWireNumber);
+	f32 posInWire  = wire->getPosInWire(unk_14);
+	gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(posInWire, &unk_20);
+
+	// TODO: Investigate this further
+	// The stack addresses used for the isnan checks are off by 0x10,
+	// regardless of whether this is before or after the isnan checks.
+	// However, this padding does align everything else above here.
+	u8 padding[0x10]; // to match allocated stack size
+
+	if (isnan(unk_20.x) || isnan(unk_20.y) || isnan(unk_20.z)) {
+		unk_20.set(actor->mPosition);
+	}
+
+	f32 fVar = 0.05f + unk_20.y;
+
+	if (unk_14.y <= fVar) {
+		actor->mLiveFlag &= ~LIVE_FLAG_AIRBORNE;
+	} else {
+		actor->mLiveFlag |= LIVE_FLAG_AIRBORNE;
+	}
+
+	actor->mLinearVelocity = unk_20 - actor->mPosition;
 }
 
-JGeometry::TVec3<f32> TWireBinder::getDirAtPos(const JGeometry::TVec3<f32>& param_1, f32 param_2) const
+JGeometry::TVec3<f32>
+TWireBinder::getDirAtPos(const JGeometry::TVec3<f32>& param_1,
+                         f32 param_2) const
 {
-    JGeometry::TVec3<f32> vec1;
-    JGeometry::TVec3<f32> vec2;
-    
-    TMapWire* wire = gpMapWireManager->unk18[mWireNumber];
-    f32 posInWire = wire->getPosInWire(param_1);
+	JGeometry::TVec3<f32> vec1;
+	JGeometry::TVec3<f32> vec2;
 
-    u8 padding[0x30]; // to match allocated stack size
+	TMapWire* wire = gpMapWireManager->unk18[mWireNumber];
+	f32 posInWire  = wire->getPosInWire(param_1);
 
-    f32 dVar1;
-    f32 dVar2;
+	u8 padding[0x30]; // to match allocated stack size
 
-    if (posInWire <= 0.01f && param_2 < 0.0f || 0.99f <= posInWire && 0.0f < param_2) {
-        dVar1 = posInWire - 0.01f * param_2;
-        dVar2 = posInWire;
-    } else {
-        dVar1 = posInWire;
-        dVar2 = posInWire + 0.01f * param_2;
-    }
-    
-    gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(dVar1, &vec1);
-    gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(dVar2, &vec2);
+	f32 dVar1;
+	f32 dVar2;
 
-    vec2.sub(vec1);
-    return vec2;
+	if (posInWire <= 0.01f && param_2 < 0.0f
+	    || 0.99f <= posInWire && 0.0f < param_2) {
+		dVar1 = posInWire - 0.01f * param_2;
+		dVar2 = posInWire;
+	} else {
+		dVar1 = posInWire;
+		dVar2 = posInWire + 0.01f * param_2;
+	}
+
+	gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(dVar1, &vec1);
+	gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(dVar2, &vec2);
+
+	vec2.sub(vec1);
+	return vec2;
 }
 
 void TWireBinder::getPoint(JGeometry::TVec3<f32>* param_1, f32 param_2) const
 {
-    gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(param_2, param_1);
+	gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(param_2, param_1);
 }
 
-void TWireBinder::getPoint(JGeometry::TVec3<float>* param_1, const JGeometry::TVec3<float>& param_2) const
+void TWireBinder::getPoint(JGeometry::TVec3<float>* param_1,
+                           const JGeometry::TVec3<float>& param_2) const
 {
-    u8 padding[0x20]; // to match allocated stack size
+	u8 padding[0x20]; // to match allocated stack size
 
-    f32 posInWire = gpMapWireManager->unk18[mWireNumber]->getPosInWire(param_2);
-    gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(posInWire, param_1);
+	f32 posInWire = gpMapWireManager->unk18[mWireNumber]->getPosInWire(param_2);
+	gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(posInWire, param_1);
 }
 
-bool TWireBinder::isEndWire(const JGeometry::TVec3<float>& param_1, f32 param_2) const
+bool TWireBinder::isEndWire(const JGeometry::TVec3<float>& param_1,
+                            f32 param_2) const
 {
-    u8 padding[0x18]; // to match allocated stack size
+	u8 padding[0x18]; // to match allocated stack size
 
-    f32 posInWire = gpMapWireManager->unk18[mWireNumber]->getPosInWire(param_1);
-    f32 targetPos = 0 < param_2 ? 1.0f : 0.0f;
+	f32 posInWire = gpMapWireManager->unk18[mWireNumber]->getPosInWire(param_1);
+	f32 targetPos = 0 < param_2 ? 1.0f : 0.0f;
 
-    return fabsf(posInWire - targetPos) < 0.015f;
+	return fabsf(posInWire - targetPos) < 0.015f;
 }
-
 
 bool TWireBinder::isOnWire(const JGeometry::TVec3<f32>& param_1)
 {
-    return gpMapWireManager->getWireNo(param_1) != -1;
+	return gpMapWireManager->getWireNo(param_1) != -1;
 }
 
-
-TWireBinder::~TWireBinder()
-{
-}
+TWireBinder::~TWireBinder() { }

--- a/src/Enemy/wireBinder.cpp
+++ b/src/Enemy/wireBinder.cpp
@@ -32,7 +32,9 @@ void TWireBinder::bind(TLiveActor* actor)
 	JGeometry::TVec3<f32> unk_20;
 	// Not sure why we use a different getWire here, but it matches
 	TMapWire* wire = gpMapWireManager->getWire(mWireNumber);
+
 	f32 posInWire = wire->getPosInWire(unk_14);
+
 	TMapWireManager::getGlobalWire(mWireNumber)
 	    ->getPointPosOnWire(posInWire, &unk_20);
 

--- a/src/Enemy/wireBinder.cpp
+++ b/src/Enemy/wireBinder.cpp
@@ -14,8 +14,8 @@ bool TWireBinder::init(const JGeometry::TVec3<f32>& param_1)
 
 	TMapWire* wire = TMapWireManager::getGlobalWire(mWireNumber);
 
-	local24 = wire->unk00;
-	local30 = wire->unk0C;
+	local24 = wire->getUnk00();
+	local30 = wire->getUnk0C();
 	local30.sub(local24);
 
 	// TODO: Why does the compiler inline stuff here but not in the target?

--- a/src/Enemy/wireBinder.cpp
+++ b/src/Enemy/wireBinder.cpp
@@ -1,0 +1,128 @@
+#include <Enemy/WireBinder.hpp>
+#include <Map/MapWire.hpp>
+#include <Map/MapWireManager.hpp>
+
+bool TWireBinder::init(const JGeometry::TVec3<f32>& param_1)
+{
+    JGeometry::TVec3<f32> local24;
+    JGeometry::TVec3<f32> local30;
+
+    mWireNumber = gpMapWireManager->getWireNo(param_1);
+    if ((s32)mWireNumber == -1) {
+        return false;
+    }
+
+    TMapWire* wire = gpMapWireManager->unk18[mWireNumber];
+
+    local24 = wire->unk00;
+    local30 = wire->unk0C;
+    local30.sub(local24);
+
+    // TODO: Why does the compiler inline stuff here but not in the target?
+    // See also: TMapObjPlane::calcNrm, TBGAttackHit::perform, etc.
+    mDir.setLength(local30, 1.0f);
+    return true;
+}
+
+void TWireBinder::bind(TLiveActor* actor)
+{
+    
+    JGeometry::TVec3<f32> unk_14 = actor->mPosition;
+    JGeometry::TVec3<f32> unk_20;
+    
+    unk_14.x += actor->mLinearVelocity.x;
+    unk_14.y += actor->mLinearVelocity.y;
+    unk_14.z += actor->mLinearVelocity.z;
+    
+    JGeometry::TVec3<f32> velocity = actor->mVelocity;
+    
+    unk_14.x += velocity.x;
+    unk_14.y += velocity.y;
+    unk_14.z += velocity.z;
+    
+    TMapWire* wire = gpMapWireManager->getWire(mWireNumber);
+    f32 posInWire = wire->getPosInWire(unk_14);
+    gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(posInWire, &unk_20);
+
+    // TODO: Investigate this further
+    // The stack addresses used for the isnan checks are off by 0x10,
+    // regardless of whether this is before or after the isnan checks.
+    // However, this padding does align everything else above here.
+    u8 padding[0x10]; // to match allocated stack size
+
+    if (isnan(unk_20.x) || isnan(unk_20.y) || isnan(unk_20.z)) {
+        unk_20.set(actor->mPosition);
+    }
+    
+    f32 fVar = 0.05f + unk_20.y;
+    
+    if (unk_14.y <= fVar) {
+        actor->mLiveFlag &= ~LIVE_FLAG_AIRBORNE;
+    } else {
+        actor->mLiveFlag |= LIVE_FLAG_AIRBORNE;
+    }
+    
+    actor->mLinearVelocity = unk_20 - actor->mPosition;
+}
+
+JGeometry::TVec3<f32> TWireBinder::getDirAtPos(const JGeometry::TVec3<f32>& param_1, f32 param_2) const
+{
+    JGeometry::TVec3<f32> vec1;
+    JGeometry::TVec3<f32> vec2;
+    
+    TMapWire* wire = gpMapWireManager->unk18[mWireNumber];
+    f32 posInWire = wire->getPosInWire(param_1);
+
+    u8 padding[0x30]; // to match allocated stack size
+
+    f32 dVar1;
+    f32 dVar2;
+
+    if (posInWire <= 0.01f && param_2 < 0.0f || 0.99f <= posInWire && 0.0f < param_2) {
+        dVar1 = posInWire - 0.01f * param_2;
+        dVar2 = posInWire;
+    } else {
+        dVar1 = posInWire;
+        dVar2 = posInWire + 0.01f * param_2;
+    }
+    
+    gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(dVar1, &vec1);
+    gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(dVar2, &vec2);
+
+    vec2.sub(vec1);
+    return vec2;
+}
+
+void TWireBinder::getPoint(JGeometry::TVec3<f32>* param_1, f32 param_2) const
+{
+    gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(param_2, param_1);
+}
+
+void TWireBinder::getPoint(JGeometry::TVec3<float>* param_1, const JGeometry::TVec3<float>& param_2) const
+{
+    u8 padding[0x20]; // to match allocated stack size
+
+    f32 posInWire = gpMapWireManager->unk18[mWireNumber]->getPosInWire(param_2);
+    gpMapWireManager->unk18[mWireNumber]->getPointPosOnWire(posInWire, param_1);
+}
+
+bool TWireBinder::isEndWire(const JGeometry::TVec3<float>& param_1, f32 param_2) const
+{
+    u8 padding[0x18]; // to match allocated stack size
+
+    f32 posInWire = gpMapWireManager->unk18[mWireNumber]->getPosInWire(param_1);
+    f32 targetPos = 0 < param_2 ? 1.0f : 0.0f;
+
+    return fabsf(posInWire - targetPos) < 0.015f;
+}
+
+
+bool TWireBinder::isOnWire(const JGeometry::TVec3<f32>& param_1)
+{
+    return gpMapWireManager->getWireNo(param_1) != -1;
+}
+
+
+TWireBinder::~TWireBinder()
+{
+}

--- a/src/Enemy/wireBinder.cpp
+++ b/src/Enemy/wireBinder.cpp
@@ -12,7 +12,7 @@ bool TWireBinder::init(const JGeometry::TVec3<f32>& param_1)
 		return false;
 	}
 
-	TMapWire* wire = gpMapWireManager->unk18[mWireNumber];
+	TMapWire* wire = TMapWireManager::getGlobalWire(mWireNumber);
 
 	local24 = wire->unk00;
 	local30 = wire->unk0C;
@@ -28,10 +28,13 @@ void TWireBinder::bind(TLiveActor* actor)
 {
 	JGeometry::TVec3<f32> unk_14;
 	actor->getNextFramePosition(unk_14);
-	
+
 	JGeometry::TVec3<f32> unk_20;
-	f32 posInWire = gpMapWireManager->getPosInWire(mWireNumber, unk_14);
-	gpMapWireManager->getPointPosOnWire(mWireNumber, posInWire, unk_20);
+	// Not sure why we use a different getWire here, but it matches
+	TMapWire* wire = gpMapWireManager->getWire(mWireNumber);
+	f32 posInWire = wire->getPosInWire(unk_14);
+	TMapWireManager::getGlobalWire(mWireNumber)
+	    ->getPointPosOnWire(posInWire, &unk_20);
 
 	if (isnan(unk_20.x) || isnan(unk_20.y) || isnan(unk_20.z)) {
 		unk_20.set(actor->getPosition());
@@ -52,13 +55,8 @@ JGeometry::TVec3<f32>
 TWireBinder::getDirAtPos(const JGeometry::TVec3<f32>& param_1,
                          f32 param_2) const
 {
-	JGeometry::TVec3<f32> vec1;
-	JGeometry::TVec3<f32> vec2;
-
-	f32 posInWire = gpMapWireManager->getPosInWire(mWireNumber, param_1);
-
-	// This would make stack addresses align, but it's too much of a hack
-	// u8 padding[0x28];
+	f32 posInWire
+	    = TMapWireManager::getGlobalWire(mWireNumber)->getPosInWire(param_1);
 
 	f32 fVar1;
 	f32 fVar2;
@@ -72,8 +70,12 @@ TWireBinder::getDirAtPos(const JGeometry::TVec3<f32>& param_1,
 		fVar2 = posInWire + 0.01f * param_2;
 	}
 
-	gpMapWireManager->getPointPosOnWire(mWireNumber, fVar1, vec1);
-	gpMapWireManager->getPointPosOnWire(mWireNumber, fVar2, vec2);
+	JGeometry::TVec3<f32> vec1;
+	JGeometry::TVec3<f32> vec2;
+	TMapWireManager::getGlobalWire(mWireNumber)
+	    ->getPointPosOnWire(fVar1, &vec1);
+	TMapWireManager::getGlobalWire(mWireNumber)
+	    ->getPointPosOnWire(fVar2, &vec2);
 
 	vec2.sub(vec1);
 	return vec2;
@@ -81,23 +83,23 @@ TWireBinder::getDirAtPos(const JGeometry::TVec3<f32>& param_1,
 
 void TWireBinder::getPoint(JGeometry::TVec3<f32>* param_1, f32 param_2) const
 {
-	gpMapWireManager->getPointPosOnWire(mWireNumber, param_2, *param_1);
+	TMapWireManager::getGlobalWire(mWireNumber)
+	    ->getPointPosOnWire(param_2, param_1);
 }
 
 void TWireBinder::getPoint(JGeometry::TVec3<float>* param_1,
                            const JGeometry::TVec3<float>& param_2) const
 {
-	f32 posInWire = gpMapWireManager->getPosInWire(mWireNumber, param_2);
+	f32 posInWire
+	    = TMapWireManager::getGlobalWire(mWireNumber)->getPosInWire(param_2);
 	getPoint(param_1, posInWire);
 }
 
 bool TWireBinder::isEndWire(const JGeometry::TVec3<float>& param_1,
                             f32 param_2) const
 {
-	// This would make stack addresses align, but it's too much of a hack
-	// u8 padding[0x18];
-
-	f32 posInWire = gpMapWireManager->getPosInWire(mWireNumber, param_1);
+	f32 posInWire
+	    = TMapWireManager::getGlobalWire(mWireNumber)->getPosInWire(param_1);
 	f32 targetPos = 0.0f < param_2 ? 1.0f : 0.0f;
 
 	return fabsf(posInWire - targetPos) < 0.015f;

--- a/src/Map/MapWire.cpp
+++ b/src/Map/MapWire.cpp
@@ -43,26 +43,26 @@ void TMapWire::init(const TCubeGeneralInfo*) { }
 
 TMapWire::TMapWire()
 {
-    unk34 = 0.0f;
-    unk38 = 0.0f;
-    unk44 = 0;
-    unk46 = 0;
-    unk48 = 0;
-    unk4C = 0.0f;
-    unk5C = 0.0f;
-    unk60 = 0.0f;
-    unk64 = 0.0f;
-    unk74 = 0.0f;
-    unk78 = 0.0f;
-    unk7C = 0;
-    unk00.zero();
-    unk0C.zero();
-    unk18.zero();
-    unk70 = 0.0f;
-    unk6C = 0.0f;
-    unk58 = 0.0f;
-    unk54 = 0.0f;
-    unk50 = 0.0f;
-    unk3C = nullptr;
-    unk40 = nullptr;
+	unk34 = 0.0f;
+	unk38 = 0.0f;
+	unk44 = 0;
+	unk46 = 0;
+	unk48 = 0;
+	unk4C = 0.0f;
+	unk5C = 0.0f;
+	unk60 = 0.0f;
+	unk64 = 0.0f;
+	unk74 = 0.0f;
+	unk78 = 0.0f;
+	unk7C = 0;
+	unk00.zero();
+	unk0C.zero();
+	unk18.zero();
+	unk70 = 0.0f;
+	unk6C = 0.0f;
+	unk58 = 0.0f;
+	unk54 = 0.0f;
+	unk50 = 0.0f;
+	unk3C = nullptr;
+	unk40 = nullptr;
 }

--- a/src/Map/MapWire.cpp
+++ b/src/Map/MapWire.cpp
@@ -1,3 +1,4 @@
+#include <types.h>
 #include <Map/MapWire.hpp>
 
 TMapWirePoint::TMapWirePoint() { }
@@ -40,4 +41,28 @@ void TMapWire::initTipPoints(const TCubeGeneralInfo*) { }
 
 void TMapWire::init(const TCubeGeneralInfo*) { }
 
-TMapWire::TMapWire() { }
+TMapWire::TMapWire()
+{
+    unk34 = 0.0f;
+    unk38 = 0.0f;
+    unk44 = 0;
+    unk46 = 0;
+    unk48 = 0;
+    unk4C = 0.0f;
+    unk5C = 0.0f;
+    unk60 = 0.0f;
+    unk64 = 0.0f;
+    unk74 = 0.0f;
+    unk78 = 0.0f;
+    unk7C = 0;
+    unk00.zero();
+    unk0C.zero();
+    unk18.zero();
+    unk70 = 0.0f;
+    unk6C = 0.0f;
+    unk58 = 0.0f;
+    unk54 = 0.0f;
+    unk50 = 0.0f;
+    unk3C = nullptr;
+    unk40 = nullptr;
+}

--- a/src/Map/MapWireManager.cpp
+++ b/src/Map/MapWireManager.cpp
@@ -86,10 +86,7 @@ TMapWireActorManager::TMapWireActorManager(TTakeActor* param_1)
 JUtility::TColor TMapWireManager::mUpperSurface;
 JUtility::TColor TMapWireManager::mLowerSurface;
 
-TMapWire* TMapWireManager::getWire(int index) const
-{
-	return unk18[index];
-}
+TMapWire* TMapWireManager::getWire(int index) const { return unk18[index]; }
 
 u32 TMapWireManager::getWireNo(const JGeometry::TVec3<f32>& param_1) const
 {

--- a/src/Map/MapWireManager.cpp
+++ b/src/Map/MapWireManager.cpp
@@ -86,6 +86,11 @@ TMapWireActorManager::TMapWireActorManager(TTakeActor* param_1)
 JUtility::TColor TMapWireManager::mUpperSurface;
 JUtility::TColor TMapWireManager::mLowerSurface;
 
+TMapWire* TMapWireManager::getWire(int index) const
+{
+	return unk18[index];
+}
+
 u32 TMapWireManager::getWireNo(const JGeometry::TVec3<f32>& param_1) const
 {
 	return gpCubeWire->getInCubeNo(param_1);

--- a/src/Map/MapWireManager.cpp
+++ b/src/Map/MapWireManager.cpp
@@ -86,8 +86,6 @@ TMapWireActorManager::TMapWireActorManager(TTakeActor* param_1)
 JUtility::TColor TMapWireManager::mUpperSurface;
 JUtility::TColor TMapWireManager::mLowerSurface;
 
-TMapWire* TMapWireManager::getWire(int index) const { return unk18[index]; }
-
 u32 TMapWireManager::getWireNo(const JGeometry::TVec3<f32>& param_1) const
 {
 	return gpCubeWire->getInCubeNo(param_1);


### PR DESCRIPTION
A first pass at the wireBunder TU, along with some extra things that I used to get it up and running.

Notes:

* The name of `TWireBinder::mDir` is inferred from the `TWireBinder::getDir()` symbol as defined in the wireTrap TU. This TU hasn't been decompiled yet, but we at least have a name, so we might as well note it.
* `TWireBinder::init` is nowhere near an exact match yet due to weird inlining stuff, but it's functionally equivalent. This issue also exists in other TUs, some of which I've noted.
* Other 99% matches are only off by stack addresses, which I imagine will get resolved eventually.
