### PR TITLE
MapObjDolpic decompilation + THitActor fixes

### DIFF
--- a/include/MoveBG/MapObjDolpic.hpp
+++ b/include/MoveBG/MapObjDolpic.hpp
@@ -10,7 +10,6 @@ class TMonumentShine : public TMapObjBase {
 public:
 	TMonumentShine(const char*);
 
-	virtual ~TMonumentShine() { }
 	virtual BOOL receiveMessage(THitActor* sender, u32 message);
 	virtual void control();
 	virtual void initMapObj();
@@ -30,7 +29,6 @@ class TBellDolpic : public TMapObjBase {
 public:
 	TBellDolpic(int, const char*);
 
-	virtual ~TBellDolpic() { }
 	virtual BOOL receiveMessage(THitActor* sender, u32 message);
 	virtual void calcRootMatrix();
 	virtual void control();
@@ -59,7 +57,6 @@ public:
 	{
 	}
 
-	virtual ~TDptMonteFence() { }
 	virtual void touchPlayer(THitActor*);
 };
 
@@ -70,7 +67,6 @@ public:
 	{
 	}
 
-	virtual ~TMapObjSmoke() { }
 	virtual void load(JSUMemoryInputStream&);
 	virtual void control();
 	virtual u32 touchWater(THitActor*);
@@ -83,7 +79,6 @@ public:
 	{
 	}
 
-	virtual ~TMareGate() { }
 	virtual void loadAfter();
 	virtual void control();
 };
@@ -98,7 +93,6 @@ public:
 	{
 	}
 
-	virtual ~TDemoCannon() { }
 	virtual void perform(u32, JDrama::TGraphics*);
 	virtual void loadAfter();
 	virtual void initMapObj();
@@ -121,7 +115,6 @@ public:
 	{
 	}
 
-	virtual ~TTurboNozzleDoor();
 	virtual void loadAfter();
 	virtual void touchPlayer(THitActor*);
 

--- a/include/MoveBG/MapObjDolpic.hpp
+++ b/include/MoveBG/MapObjDolpic.hpp
@@ -1,0 +1,133 @@
+#ifndef MOVE_BG_MAP_OBJ_DOLPIC_HPP
+#define MOVE_BG_MAP_OBJ_DOLPIC_HPP
+
+#include <MoveBG/MapObjBase.hpp>
+#include <MoveBG/MapObjHide.hpp>
+
+class TSharedParts;
+
+class TMonumentShine : public TMapObjBase {
+public:
+	TMonumentShine(const char*);
+
+	virtual ~TMonumentShine() { }
+	virtual BOOL receiveMessage(THitActor* sender, u32 message);
+	virtual void control();
+	virtual void initMapObj();
+
+	void hitByWater(THitActor*);
+
+public:
+	/* 0x138 */ GXColor unk138;
+	/* 0x13C */ int unk13C;
+	/* 0x140 */ f32 unk140;
+	/* 0x144 */ int unk144;
+	/* 0x148 */ s8 unk148;
+	/* 0x149 */ s8 unk149;
+};
+
+class TBellDolpic : public TMapObjBase {
+public:
+	TBellDolpic(int, const char*);
+
+	virtual ~TBellDolpic() { }
+	virtual BOOL receiveMessage(THitActor* sender, u32 message);
+	virtual void calcRootMatrix();
+	virtual void control();
+	virtual void initMapObj();
+	virtual void touchPlayer(THitActor*);
+
+	void ring(const JGeometry::TVec3<f32>&);
+
+public:
+	/* 0x138 */ GXColor unk138;
+	/* 0x13C */ int unk13C;
+	/* 0x140 */ f32 unk140;
+	/* 0x144 */ f32 unk144;
+	/* 0x148 */ f32 unk148;
+	/* 0x14C */ f32 unk14C;
+	/* 0x150 */ f32 unk150;
+	/* 0x154 */ int unk154;
+	/* 0x158 */ int unk158;
+	/* 0x15C */ s8 unk15C;
+};
+
+class TDptMonteFence : public TMapObjBase {
+public:
+	TDptMonteFence(const char* name)
+	    : TMapObjBase(name)
+	{
+	}
+
+	virtual ~TDptMonteFence() { }
+	virtual void touchPlayer(THitActor*);
+};
+
+class TMapObjSmoke : public THideObjBase {
+public:
+	TMapObjSmoke(const char* name)
+	    : THideObjBase(name)
+	{
+	}
+
+	virtual ~TMapObjSmoke() { }
+	virtual void load(JSUMemoryInputStream&);
+	virtual void control();
+	virtual u32 touchWater(THitActor*);
+};
+
+class TMareGate : public TMapObjBase {
+public:
+	TMareGate(const char* name)
+	    : TMapObjBase(name)
+	{
+	}
+
+	virtual ~TMareGate() { }
+	virtual void loadAfter();
+	virtual void control();
+};
+
+class TDemoCannon : public TMapObjBase {
+public:
+	TDemoCannon(const char* name)
+	    : TMapObjBase(name)
+	    , unk138(nullptr)
+	    , unk13C(nullptr)
+	    , unk14C(0)
+	{
+	}
+
+	virtual ~TDemoCannon() { }
+	virtual void perform(u32, JDrama::TGraphics*);
+	virtual void loadAfter();
+	virtual void initMapObj();
+
+	void startDemo();
+
+public:
+	/* 0x138 */ TSharedParts* unk138;
+	/* 0x13C */ TSharedParts* unk13C;
+	/* 0x140 */ u8 pad140[0xC];
+	/* 0x14C */ u8 unk14C;
+};
+
+class TTurboNozzleDoor : public TMapObjBase {
+public:
+	TTurboNozzleDoor(const char* name)
+	    : TMapObjBase(name)
+	    , unk138()
+	    , unk144(nullptr)
+	{
+	}
+
+	virtual ~TTurboNozzleDoor();
+	virtual void loadAfter();
+	virtual void touchPlayer(THitActor*);
+
+public:
+	/* 0x138 */ JGeometry::TVec3<f32> unk138;
+	/* 0x144 */ TLiveActor* unk144;
+};
+
+#endif

--- a/include/Strategic/HitActor.hpp
+++ b/include/Strategic/HitActor.hpp
@@ -46,16 +46,6 @@ public:
 
 	// fabricated
 	u32 getActorType() const { return mActorType; }
-	u8 isActorTypeOf(u32 base) const
-	{
-		u8 result;
-		if ((mActorType - base) == 1) {
-			result = 1;
-		} else {
-			result = 0;
-		}
-		return result;
-	}
 	bool checkActorType(u32 flag) const
 	{
 		return mActorType & flag ? true : false;

--- a/include/Strategic/HitActor.hpp
+++ b/include/Strategic/HitActor.hpp
@@ -46,6 +46,16 @@ public:
 
 	// fabricated
 	u32 getActorType() const { return mActorType; }
+	u8 isActorTypeOf(u32 base) const
+	{
+		u8 result;
+		if ((mActorType - base) == 1) {
+			result = 1;
+		} else {
+			result = 0;
+		}
+		return result;
+	}
 	bool checkActorType(u32 flag) const
 	{
 		return mActorType & flag ? true : false;

--- a/src/MoveBG/MapObjDolpic.cpp
+++ b/src/MoveBG/MapObjDolpic.cpp
@@ -26,6 +26,18 @@
 // rogue includes needed for matching sinit & rodata
 #include <M3DUtil/InfectiousStrings.hpp>
 
+// fabricated helper for boolean materialization matching
+static u8 isActorTypeOf(THitActor* actor, u32 base)
+{
+	u8 result;
+	if ((actor->mActorType - base) == 1) {
+		result = 1;
+	} else {
+		result = 0;
+	}
+	return result;
+}
+
 // TMonumentShine
 
 TMonumentShine::TMonumentShine(const char* name)
@@ -49,12 +61,12 @@ void TMonumentShine::initMapObj()
 
 	if (TFlagManager::getInstance()->getFlag(0x10063) != 0) {
 		unk138.a = 0;
-		unk13C = 0;
-		unk149 = 1;
+		unk13C   = 0;
+		unk149   = 1;
 	} else {
 		unk138.a = 100;
-		unk13C = 1000;
-		unk149 = 0;
+		unk13C   = 1000;
+		unk149   = 0;
 	}
 
 	SMS_InitPacket_OneTevKColor(getModel(), 0, GX_KCOLOR0, &unk138);
@@ -74,15 +86,16 @@ void TMonumentShine::hitByWater(THitActor* actor)
 	(void)_pad;
 
 	waterDir = actor->mPosition;
-	f32 px = mPosition.x;
-	f32 py = mPosition.y;
-	f32 pz = mPosition.z;
+	f32 px   = mPosition.x;
+	f32 py   = mPosition.y;
+	f32 pz   = mPosition.z;
 	waterDir.x -= px;
 	waterDir.y -= py;
 	waterDir.z -= pz;
 	waterDir.y = 0.0f;
 
-	f32 lenSq = waterDir.x * waterDir.x + waterDir.z * waterDir.z + waterDir.y * waterDir.y;
+	f32 lenSq = waterDir.x * waterDir.x + waterDir.z * waterDir.z
+	            + waterDir.y * waterDir.y;
 	if (lenSq <= 0.0000038146973f)
 		return;
 	marioDir = *gpMarioPos;
@@ -91,7 +104,8 @@ void TMonumentShine::hitByWater(THitActor* actor)
 	marioDir.z -= pz;
 	marioDir.y = 0.0f;
 
-	f32 lenSq2 = marioDir.x * marioDir.x + marioDir.y * marioDir.y + marioDir.z * marioDir.z;
+	f32 lenSq2 = marioDir.x * marioDir.x + marioDir.y * marioDir.y
+	             + marioDir.z * marioDir.z;
 	if (lenSq2 <= 0.0000038146973f)
 		return;
 
@@ -119,9 +133,10 @@ BOOL TMonumentShine::receiveMessage(THitActor* sender, u32 message)
 	f32 _pad[2];
 	(void)_pad;
 
-	if (sender->isActorTypeOf(0x01000000)) {
+	if (isActorTypeOf(sender, 0x01000000)) {
 		gpMarioParticleManager->emit(0xE7, &sender->mPosition, 0, nullptr);
-		gpMSound->startSoundSet(0x6802, (const Vec*)&sender->mPosition, 0, 0.0f, 0, 0, 4);
+		gpMSound->startSoundSet(0x6802, (const Vec*)&sender->mPosition, 0, 0.0f,
+		                        0, 0, 4);
 
 		if (unk13C == 0)
 			return 1;
@@ -133,12 +148,13 @@ BOOL TMonumentShine::receiveMessage(THitActor* sender, u32 message)
 
 		if (unk13C == 0) {
 			gpItemManager->makeShineAppearWithDemo(
-			    "\x83\x56\x83\x83\x83\x43\x83\x93\x81\x69\x83\x82\x83\x6A\x83\x85\x83\x81\x83\x93\x83\x67\x83\x56\x83\x83\x83\x43\x83\x93\x97\x70\x81\x6A",
-			    "\x83\x82\x83\x6A\x83\x85\x83\x81\x83\x93\x83\x67\x83\x56\x83\x83\x83\x43\x83\x93\x83\x4A\x83\x81\x83\x89",
-			    mPosition.x, mPosition.y, mPosition.z);
+			    "シャイン（モニュメントシャイン用）",
+			    "モニュメントシャインカメラ", mPosition.x, mPosition.y,
+			    mPosition.z);
 
 			if (gpMSound->gateCheck(0x484A)) {
-				MSoundSESystem::MSoundSE::startSoundSystemSE(0x484A, 0, nullptr, 0);
+				MSoundSESystem::MSoundSE::startSoundSystemSE(0x484A, 0, nullptr,
+				                                             0);
 			}
 		}
 
@@ -168,18 +184,20 @@ void TMonumentShine::control()
 	if (fabsf(unk140) < 0.1f) {
 		if (unk144 == 2) {
 			if (unk148 > 0) {
-				f32 rot = mRotation.y;
+				f32 rot    = mRotation.y;
 				f32 target = mInitialRotation.y + 360.0f;
-				f32 diff = target - MsWrap(rot, target - 180.0f, target + 180.0f);
+				f32 diff
+				    = target - MsWrap(rot, target - 180.0f, target + 180.0f);
 				if (diff > 0.1f)
 					diff = 0.1f;
 				if (0.0f == diff)
 					unk144++;
 				mAngularVelocity.y += diff;
 			} else {
-				f32 rot = mRotation.y;
+				f32 rot    = mRotation.y;
 				f32 target = mInitialRotation.y - 360.0f;
-				f32 diff = target - MsWrap(rot, target - 180.0f, target + 180.0f);
+				f32 diff
+				    = target - MsWrap(rot, target - 180.0f, target + 180.0f);
 				if (diff < -0.1f)
 					diff = -0.1f;
 				if (0.0f == diff)
@@ -204,7 +222,7 @@ void TMonumentShine::control()
 			}
 		}
 	} else {
-		f32 rot = mRotation.y;
+		f32 rot   = mRotation.y;
 		f32 limit = 360.0f;
 		while (rot >= limit)
 			rot -= limit;
@@ -240,23 +258,15 @@ void TBellDolpic::initMapObj()
 	unk138.g = 0xFF;
 	unk138.b = 0xFF;
 
-	if (unk13C != 0)
-		goto check1;
-	if (TFlagManager::getInstance()->getFlag(0x10061) != 0)
-		goto setZero;
-check1:
-	if (unk13C != 1)
-		goto set100;
-	if (TFlagManager::getInstance()->getFlag(0x10060) == 0)
-		goto set100;
-setZero:
-	unk138.a = 0;
-	unk154 = 0;
-	goto done;
-set100:
-	unk138.a = 100;
-	unk154 = 1000;
-done:;
+	if ((unk13C == 0 && TFlagManager::getInstance()->getFlag(0x10061) != 0)
+	    || (unk13C == 1
+	        && TFlagManager::getInstance()->getFlag(0x10060) != 0)) {
+		unk138.a = 0;
+		unk154   = 0;
+	} else {
+		unk138.a = 100;
+		unk154   = 1000;
+	}
 
 	SMS_InitPacket_OneTevKColor(getModel(), 0, GX_KCOLOR0, &unk138);
 	unk64 &= ~1;
@@ -313,26 +323,23 @@ void TBellDolpic::ring(const JGeometry::TVec3<f32>& pos)
 
 	unk150 -= 0.5f;
 
-	int r = rand();
+	int r   = rand();
 	f32 tmp = (f32)r * 0.000030517578f;
-	unk158 = (int)(tmp * 14400.0f) + 0x5460;
+	unk158  = (int)(tmp * 14400.0f) + 0x5460;
 }
 
-void TBellDolpic::touchPlayer(THitActor* actor)
-{
-	ring(actor->mPosition);
-}
+void TBellDolpic::touchPlayer(THitActor* actor) { ring(actor->mPosition); }
 
 BOOL TBellDolpic::receiveMessage(THitActor* sender, u32 message)
 {
 	f32 _pad[2];
 	(void)_pad;
 
-	if (sender->isActorTypeOf(0x80000000)) {
+	if (isActorTypeOf(sender, 0x80000000)) {
 		ring(sender->mPosition);
 	}
 
-	if (sender->isActorTypeOf(0x01000000)) {
+	if (isActorTypeOf(sender, 0x01000000)) {
 		gpMarioParticleManager->emit(0xE7, &sender->mPosition, 0, nullptr);
 
 		if (unk154 == 0)
@@ -345,18 +352,19 @@ BOOL TBellDolpic::receiveMessage(THitActor* sender, u32 message)
 		if (unk154 == 0) {
 			if (unk13C == 0) {
 				gpItemManager->makeShineAppearWithDemo(
-				    "\x83\x56\x83\x83\x83\x43\x83\x93\x81\x69\x83\x68\x83\x8B\x83\x73\x83\x62\x83\x4E\x8F\xE0\x8C\x78\x8E\x40\x8F\x90\x97\x70\x81\x6A",
-				    "\x83\x68\x83\x8B\x83\x73\x83\x62\x83\x4E\x8F\xE0\x8C\x78\x8E\x40\x8F\x90\x83\x4A\x83\x81\x83\x89",
-				    mPosition.x, mPosition.y, mPosition.z);
+				    "シャイン（ドルピック鐘警察署用）",
+				    "ドルピック鐘警察署カメラ", mPosition.x, mPosition.y,
+				    mPosition.z);
 			} else {
 				gpItemManager->makeShineAppearWithDemo(
-				    "\x83\x56\x83\x83\x83\x43\x83\x93\x81\x69\x83\x68\x83\x8B\x83\x73\x83\x62\x83\x4E\x8F\xE0\x83\x65\x83\x83\x83\x8C\x83\x72\x8B\xC7\x97\x70\x81\x6A",
-				    "\x83\x68\x83\x8B\x83\x73\x83\x62\x83\x4E\x8F\xE0\x83\x65\x83\x83\x83\x8C\x83\x72\x8B\xC7\x83\x4A\x83\x81\x83\x89",
-				    mPosition.x, mPosition.y, mPosition.z);
+				    "シャイン（ドルピック鐘テャレビ局用）",
+				    "ドルピック鐘テャレビ局カメラ", mPosition.x, mPosition.y,
+				    mPosition.z);
 			}
 
 			if (gpMSound->gateCheck(0x484A)) {
-				MSoundSESystem::MSoundSE::startSoundSystemSE(0x484A, 0, nullptr, 0);
+				MSoundSESystem::MSoundSE::startSoundSystemSE(0x484A, 0, nullptr,
+				                                             0);
 			}
 		}
 
@@ -385,7 +393,7 @@ void TBellDolpic::control()
 	TMapObjBase::control();
 
 	f32 sinVal = -JMASin(unk14C);
-	unk150 = 0.01f * sinVal + unk150;
+	unk150     = 0.01f * sinVal + unk150;
 
 	unk14C = unk14C + unk150;
 
@@ -395,21 +403,25 @@ void TBellDolpic::control()
 		if (unk154 == 0) {
 			if (unk15C) {
 				if (gpMSound->gateCheck(0x38A5)) {
-					MSoundSESystem::MSoundSE::startSoundActor(0x38A5, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+					MSoundSESystem::MSoundSE::startSoundActor(
+					    0x38A5, (const Vec*)&mPosition, 0, nullptr, 0, 4);
 				}
 			} else {
 				if (gpMSound->gateCheck(0x38A6)) {
-					MSoundSESystem::MSoundSE::startSoundActor(0x38A6, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+					MSoundSESystem::MSoundSE::startSoundActor(
+					    0x38A6, (const Vec*)&mPosition, 0, nullptr, 0, 4);
 				}
 			}
 		} else {
 			if (unk15C) {
 				if (gpMSound->gateCheck(0x38A8)) {
-					MSoundSESystem::MSoundSE::startSoundActor(0x38A8, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+					MSoundSESystem::MSoundSE::startSoundActor(
+					    0x38A8, (const Vec*)&mPosition, 0, nullptr, 0, 4);
 				}
 			} else {
 				if (gpMSound->gateCheck(0x38A9)) {
-					MSoundSESystem::MSoundSE::startSoundActor(0x38A9, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+					MSoundSESystem::MSoundSE::startSoundActor(
+					    0x38A9, (const Vec*)&mPosition, 0, nullptr, 0, 4);
 				}
 			}
 		}
@@ -429,10 +441,12 @@ void TDptMonteFence::touchPlayer(THitActor* actor)
 
 	if (SMS_IsMarioStatusThrownDown()) {
 		if (gpMSound->gateCheck(0x380A)) {
-			MSoundSESystem::MSoundSE::startSoundActor(0x380A, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+			MSoundSESystem::MSoundSE::startSoundActor(
+			    0x380A, (const Vec*)&mPosition, 0, nullptr, 0, 4);
 		}
 		if (gpMSound->gateCheck(0x3857)) {
-			MSoundSESystem::MSoundSE::startSoundActor(0x3857, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+			MSoundSESystem::MSoundSE::startSoundActor(
+			    0x3857, (const Vec*)&mPosition, 0, nullptr, 0, 4);
 		}
 		kill();
 	}
@@ -468,7 +482,8 @@ void TMareGate::control()
 	TMapObjBase::control();
 	MSound* sound = gpMSound;
 	if (sound->gateCheck(0x3085)) {
-		MSoundSESystem::MSoundSE::startSoundActor(0x3085, (const Vec*)&mPosition, 0, (JAISound**)&sound->unk7C, 0, 4);
+		MSoundSESystem::MSoundSE::startSoundActor(
+		    0x3085, (const Vec*)&mPosition, 0, (JAISound**)&sound->unk7C, 0, 4);
 	}
 }
 
@@ -494,27 +509,28 @@ void TDemoCannon::loadAfter()
 
 void TDemoCannon::initMapObj()
 {
-	f32 _pad[2];
-	(void)_pad;
-
 	TMapObjBase::initMapObj();
 
 	mMActor->setBck("democannon_dpt");
-	J3DFrameCtrl* frameCtrl = mMActor->getFrameCtrl(0);
+	J3DFrameCtrl* frameCtrl  = mMActor->getFrameCtrl(0);
 	frameCtrl->mCurrentFrame = (f32)frameCtrl->mEndFrame;
 
-	void* res = JKRFileLoader::getGlbResource("/scene/mapObj/demoCannon_dom.bmd");
-	SDLModelData* sdlData = new SDLModelData(J3DModelLoaderDataBase::load(res, 0x10050000));
+	void* res
+	    = JKRFileLoader::getGlbResource("/scene/mapObj/demoCannon_dom.bmd");
+	SDLModelData* sdlData
+	    = new SDLModelData(J3DModelLoaderDataBase::load(res, 0x10050000));
 
 	JUTNameTab* jointName = mMActor->getModel()->getModelData()->getJointName();
 
-	TSharedParts* parts = new TSharedParts(this, jointName->getIndex("nullA"), sdlData, 3, "<TSharedParts>");
-	unk138 = parts;
+	TSharedParts* parts = new TSharedParts(this, jointName->getIndex("nullA"),
+	                                       sdlData, 3, "<TSharedParts>");
+	unk138              = parts;
 
 	res = JKRFileLoader::getGlbResource("/scene/mapObj/demoCannon_mario.bmd");
-	SDLModelData* sdlData2 = new SDLModelData(J3DModelLoaderDataBase::load(res, 0x10010000));
+	SDLModelData* sdlData2
+	    = new SDLModelData(J3DModelLoaderDataBase::load(res, 0x10010000));
 
-	parts = new TSharedParts(this, 0, sdlData2, 3, "<TSharedParts>");
+	parts  = new TSharedParts(this, 0, sdlData2, 3, "<TSharedParts>");
 	unk13C = parts;
 }
 
@@ -523,7 +539,7 @@ void TDemoCannon::startDemo()
 	unk14C = 1;
 
 	MSound* sound = gpMSound;
-	s16 hp = SMS_GetMarioHP();
+	s16 hp        = SMS_GetMarioHP();
 	sound->startMarioVoice(30911, hp, 0);
 
 	mMActor->setBck("democannon_dpt");
@@ -533,11 +549,6 @@ void TDemoCannon::startDemo()
 
 void TDemoCannon::perform(u32 flags, JDrama::TGraphics* gfx)
 {
-	f32 _pad1[3];
-	volatile f32 f;
-	f32 _pad2[10];
-	(void)_pad1; (void)_pad2;
-
 	TMapObjBase::perform(flags, gfx);
 
 	if (!unk14C)
@@ -552,7 +563,8 @@ void TDemoCannon::perform(u32 flags, JDrama::TGraphics* gfx)
 	J3DFrameCtrl* frameCtrl = unk13C->getMActor()->getFrameCtrl(0);
 	if (frameCtrl->mCurrentFrame < 174.0f) {
 		if (gpMSound->gateCheck(8392))
-			MSoundSESystem::MSoundSE::startSoundActor(8392, &mPosition, 0, nullptr, 0, 4);
+			MSoundSESystem::MSoundSE::startSoundActor(8392, &mPosition, 0,
+			                                          nullptr, 0, 4);
 	}
 
 	frameCtrl = unk13C->getMActor()->getFrameCtrl(0);
@@ -562,16 +574,23 @@ void TDemoCannon::perform(u32 flags, JDrama::TGraphics* gfx)
 
 		Mtx* mtx = unk138->getMActor()->getModel()->mNodeMatrices;
 
-		gpMarioParticleManager->emitAndBindToMtxPtr(232, (MtxPtr)mtx, 0, nullptr);
-		gpMarioParticleManager->emitAndBindToMtxPtr(233, (MtxPtr)mtx, 0, nullptr);
-		gpMarioParticleManager->emitAndBindToMtxPtr(234, (MtxPtr)mtx, 0, nullptr);
-		gpMarioParticleManager->emitAndBindToMtxPtr(235, (MtxPtr)mtx, 0, nullptr);
-		gpMarioParticleManager->emitAndBindToMtxPtr(236, (MtxPtr)mtx, 0, nullptr);
+		gpMarioParticleManager->emitAndBindToMtxPtr(232, (MtxPtr)mtx, 0,
+		                                            nullptr);
+		gpMarioParticleManager->emitAndBindToMtxPtr(233, (MtxPtr)mtx, 0,
+		                                            nullptr);
+		gpMarioParticleManager->emitAndBindToMtxPtr(234, (MtxPtr)mtx, 0,
+		                                            nullptr);
+		gpMarioParticleManager->emitAndBindToMtxPtr(235, (MtxPtr)mtx, 0,
+		                                            nullptr);
+		gpMarioParticleManager->emitAndBindToMtxPtr(236, (MtxPtr)mtx, 0,
+		                                            nullptr);
 
 		if (gpMSound->gateCheck(10574))
-			MSoundSESystem::MSoundSE::startSoundActor(10574, &mPosition, 0, nullptr, 0, 4);
+			MSoundSESystem::MSoundSE::startSoundActor(10574, &mPosition, 0,
+			                                          nullptr, 0, 4);
 		if (gpMSound->gateCheck(10605))
-			MSoundSESystem::MSoundSE::startSoundActor(10605, &mPosition, 0, nullptr, 0, 4);
+			MSoundSESystem::MSoundSE::startSoundActor(10605, &mPosition, 0,
+			                                          nullptr, 0, 4);
 	}
 
 	frameCtrl = unk13C->getMActor()->getFrameCtrl(0);
@@ -588,18 +607,14 @@ void TTurboNozzleDoor::loadAfter()
 	f32 _pad[8];
 	(void)_pad;
 
-	if (strcmp("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x4f", mName) == 0) {
-		JDrama::TNameRef* root = JDrama::TNameRefGen::getInstance()->getRootNameRef();
-		unk144 = (TLiveActor*)root->searchF(JDrama::TNameRef::calcKeyCode("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x50"), "\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x50");
-	} else if (strcmp("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x50", mName) == 0) {
-		JDrama::TNameRef* root = JDrama::TNameRefGen::getInstance()->getRootNameRef();
-		unk144 = (TLiveActor*)root->searchF(JDrama::TNameRef::calcKeyCode("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x4f"), "\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x4f");
-	} else if (strcmp("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x4f", mName) == 0) {
-		JDrama::TNameRef* root = JDrama::TNameRefGen::getInstance()->getRootNameRef();
-		unk144 = (TLiveActor*)root->searchF(JDrama::TNameRef::calcKeyCode("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x50"), "\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x50");
-	} else if (strcmp("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x50", mName) == 0) {
-		JDrama::TNameRef* root = JDrama::TNameRefGen::getInstance()->getRootNameRef();
-		unk144 = (TLiveActor*)root->searchF(JDrama::TNameRef::calcKeyCode("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x4f"), "\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x4f");
+	if (strcmp("空港ドアＡ０", mName) == 0) {
+		unk144 = JDrama::TNameRefGen::search<TLiveActor>("空港ドアＡ１");
+	} else if (strcmp("空港ドアＡ１", mName) == 0) {
+		unk144 = JDrama::TNameRefGen::search<TLiveActor>("空港ドアＡ０");
+	} else if (strcmp("空港ドアＢ０", mName) == 0) {
+		unk144 = JDrama::TNameRefGen::search<TLiveActor>("空港ドアＢ１");
+	} else if (strcmp("空港ドアＢ１", mName) == 0) {
+		unk144 = JDrama::TNameRefGen::search<TLiveActor>("空港ドアＢ０");
 	}
 }
 
@@ -616,9 +631,11 @@ void TTurboNozzleDoor::touchPlayer(THitActor* player)
 	}
 
 	if (gpMSound->gateCheck(14346))
-		MSoundSESystem::MSoundSE::startSoundActor(14346, &mPosition, 0, nullptr, 0, 4);
+		MSoundSESystem::MSoundSE::startSoundActor(14346, &mPosition, 0, nullptr,
+		                                          0, 4);
 	if (gpMSound->gateCheck(14423))
-		MSoundSESystem::MSoundSE::startSoundActor(14423, &mPosition, 0, nullptr, 0, 4);
+		MSoundSESystem::MSoundSE::startSoundActor(14423, &mPosition, 0, nullptr,
+		                                          0, 4);
 
 	JGeometry::TVec3<f32> scale;
 	f32 _pad[8];
@@ -640,5 +657,3 @@ void TTurboNozzleDoor::touchPlayer(THitActor* player)
 	removeMapCollision();
 	unk64 |= 1;
 }
-
-TTurboNozzleDoor::~TTurboNozzleDoor() { }

--- a/src/MoveBG/MapObjDolpic.cpp
+++ b/src/MoveBG/MapObjDolpic.cpp
@@ -1,1 +1,644 @@
+#include <MoveBG/MapObjDolpic.hpp>
+#include <MoveBG/ItemManager.hpp>
+#include <Player/MarioAccess.hpp>
+#include <System/MarDirector.hpp>
+#include <System/Particles.hpp>
+#include <System/EmitterViewObj.hpp>
+#include <System/FlagManager.hpp>
+#include <MSound/MSound.hpp>
+#include <MSound/MSoundBGM.hpp>
+#include <MSound/MSoundSE.hpp>
+#include <MarioUtil/MathUtil.hpp>
+#include <MarioUtil/PacketUtil.hpp>
+#include <MarioUtil/RumbleMgr.hpp>
+#include <Camera/CameraShake.hpp>
+#include <Strategic/SharedParts.hpp>
+#include <M3DUtil/MActor.hpp>
+#include <M3DUtil/SDLModel.hpp>
+#include <JSystem/JDrama/JDRNameRefGen.hpp>
+#include <JSystem/JKernel/JKRFileLoader.hpp>
+#include <JSystem/J3D/J3DGraphLoader/J3DModelLoader.hpp>
+#include <JSystem/J3D/J3DGraphAnimator/J3DAnimation.hpp>
+#include <JSystem/JMath.hpp>
+#include <dolphin/mtx.h>
+#include <stdlib.h>
 
+// rogue includes needed for matching sinit & rodata
+#include <M3DUtil/InfectiousStrings.hpp>
+
+// TMonumentShine
+
+TMonumentShine::TMonumentShine(const char* name)
+    : TMapObjBase(name)
+{
+	unk13C = 1000;
+	unk140 = 0.0f;
+	unk144 = 0;
+	unk148 = 1;
+	unk149 = 0;
+}
+
+void TMonumentShine::initMapObj()
+{
+	TMapObjBase::initMapObj();
+	mMActor->offMakeDL();
+
+	unk138.r = 0xFF;
+	unk138.g = 0xFF;
+	unk138.b = 0xFF;
+
+	if (TFlagManager::getInstance()->getFlag(0x10063) != 0) {
+		unk138.a = 0;
+		unk13C = 0;
+		unk149 = 1;
+	} else {
+		unk138.a = 100;
+		unk13C = 1000;
+		unk149 = 0;
+	}
+
+	SMS_InitPacket_OneTevKColor(getModel(), 0, GX_KCOLOR0, &unk138);
+	unk64 &= ~1;
+}
+
+static JGeometry::TVec3<f32> sUpHBW;
+static s8 sInitHBW;
+static JGeometry::TVec3<f32> sUpRing;
+static s8 sInitRing;
+
+void TMonumentShine::hitByWater(THitActor* actor)
+{
+	JGeometry::TVec3<f32> waterDir;
+	JGeometry::TVec3<f32> marioDir;
+	f32 _pad[7];
+	(void)_pad;
+
+	waterDir = actor->mPosition;
+	f32 px = mPosition.x;
+	f32 py = mPosition.y;
+	f32 pz = mPosition.z;
+	waterDir.x -= px;
+	waterDir.y -= py;
+	waterDir.z -= pz;
+	waterDir.y = 0.0f;
+
+	f32 lenSq = waterDir.x * waterDir.x + waterDir.z * waterDir.z + waterDir.y * waterDir.y;
+	if (lenSq <= 0.0000038146973f)
+		return;
+	marioDir = *gpMarioPos;
+	marioDir.x -= px;
+	marioDir.y -= py;
+	marioDir.z -= pz;
+	marioDir.y = 0.0f;
+
+	f32 lenSq2 = marioDir.x * marioDir.x + marioDir.y * marioDir.y + marioDir.z * marioDir.z;
+	if (lenSq2 <= 0.0000038146973f)
+		return;
+
+	if (!sInitHBW) {
+		sUpHBW.x = 0.0f;
+		sUpHBW.y = 1.0f;
+		sUpHBW.z = 0.0f;
+		sInitHBW = true;
+	}
+
+	f32 cx = sUpHBW.y * marioDir.z - sUpHBW.z * marioDir.y;
+	f32 cy = sUpHBW.z * marioDir.x - sUpHBW.x * marioDir.z;
+	f32 cz = sUpHBW.x * marioDir.y - sUpHBW.y * marioDir.x;
+
+	f32 dot = cx * waterDir.y + cy * waterDir.x + cz * waterDir.z;
+	if (dot > 0.0f) {
+		unk140 += 0.004f;
+	} else {
+		unk140 -= 0.004f;
+	}
+}
+
+BOOL TMonumentShine::receiveMessage(THitActor* sender, u32 message)
+{
+	f32 _pad[2];
+	(void)_pad;
+
+	if (sender->isActorTypeOf(0x01000000)) {
+		gpMarioParticleManager->emit(0xE7, &sender->mPosition, 0, nullptr);
+		gpMSound->startSoundSet(0x6802, (const Vec*)&sender->mPosition, 0, 0.0f, 0, 0, 4);
+
+		if (unk13C == 0)
+			return 1;
+
+		unk13C = unk13C - 1;
+		hitByWater(sender);
+
+		unk138.a = (u8)(unk13C * 100 / 1000);
+
+		if (unk13C == 0) {
+			gpItemManager->makeShineAppearWithDemo(
+			    "\x83\x56\x83\x83\x83\x43\x83\x93\x81\x69\x83\x82\x83\x6A\x83\x85\x83\x81\x83\x93\x83\x67\x83\x56\x83\x83\x83\x43\x83\x93\x97\x70\x81\x6A",
+			    "\x83\x82\x83\x6A\x83\x85\x83\x81\x83\x93\x83\x67\x83\x56\x83\x83\x83\x43\x83\x93\x83\x4A\x83\x81\x83\x89",
+			    mPosition.x, mPosition.y, mPosition.z);
+
+			if (gpMSound->gateCheck(0x484A)) {
+				MSoundSESystem::MSoundSE::startSoundSystemSE(0x484A, 0, nullptr, 0);
+			}
+		}
+
+		return 1;
+	}
+
+	return 0;
+}
+
+void TMonumentShine::control()
+{
+	TMapObjBase::control();
+
+	if (unk149)
+		return;
+	if (unk144 >= 3)
+		return;
+
+	unk140 *= 0.9992f;
+	mAngularVelocity.y += unk140;
+
+	if (unk13C > 0) {
+		unk148 = (unk140 > 0.0f) ? 1 : -1;
+		return;
+	}
+
+	if (fabsf(unk140) < 0.1f) {
+		if (unk144 == 2) {
+			if (unk148 > 0) {
+				f32 rot = mRotation.y;
+				f32 target = mInitialRotation.y + 360.0f;
+				f32 diff = target - MsWrap(rot, target - 180.0f, target + 180.0f);
+				if (diff > 0.1f)
+					diff = 0.1f;
+				if (0.0f == diff)
+					unk144++;
+				mAngularVelocity.y += diff;
+			} else {
+				f32 rot = mRotation.y;
+				f32 target = mInitialRotation.y - 360.0f;
+				f32 diff = target - MsWrap(rot, target - 180.0f, target + 180.0f);
+				if (diff < -0.1f)
+					diff = -0.1f;
+				if (0.0f == diff)
+					unk144++;
+				mAngularVelocity.y += diff;
+			}
+		} else {
+			if (unk148 > 0) {
+				mAngularVelocity.y += 0.1f;
+				while (mRotation.y + mAngularVelocity.y > 360.0f) {
+					mRotation.y -= 360.0f;
+					unk144++;
+				}
+			} else {
+				mAngularVelocity.y -= 0.1f;
+				f32 step = 360.0f;
+				f32 zero = 0.0f;
+				while (mRotation.y + mAngularVelocity.y < zero) {
+					mRotation.y += step;
+					unk144++;
+				}
+			}
+		}
+	} else {
+		f32 rot = mRotation.y;
+		f32 limit = 360.0f;
+		while (rot >= limit)
+			rot -= limit;
+		f32 zero = 0.0f;
+		while (rot < zero)
+			rot += limit;
+		mRotation.y = rot;
+	}
+}
+
+// TBellDolpic
+
+TBellDolpic::TBellDolpic(int param_1, const char* name)
+    : TMapObjBase(name)
+{
+	unk13C = param_1;
+	unk140 = 1.0f;
+	unk144 = 0.0f;
+	unk148 = 0.0f;
+	unk14C = 0.0f;
+	unk150 = 0.0f;
+	unk154 = 1000;
+	unk158 = 0;
+	unk15C = 0;
+}
+
+void TBellDolpic::initMapObj()
+{
+	TMapObjBase::initMapObj();
+	mMActor->offMakeDL();
+
+	unk138.r = 0xFF;
+	unk138.g = 0xFF;
+	unk138.b = 0xFF;
+
+	if (unk13C != 0)
+		goto check1;
+	if (TFlagManager::getInstance()->getFlag(0x10061) != 0)
+		goto setZero;
+check1:
+	if (unk13C != 1)
+		goto set100;
+	if (TFlagManager::getInstance()->getFlag(0x10060) == 0)
+		goto set100;
+setZero:
+	unk138.a = 0;
+	unk154 = 0;
+	goto done;
+set100:
+	unk138.a = 100;
+	unk154 = 1000;
+done:;
+
+	SMS_InitPacket_OneTevKColor(getModel(), 0, GX_KCOLOR0, &unk138);
+	unk64 &= ~1;
+}
+
+void TBellDolpic::calcRootMatrix()
+{
+	TMapObjBase::calcRootMatrix();
+	J3DModel* model = getModel();
+	Mtx temp;
+	PSMTXRotAxisRad(temp, (Vec*)&unk140, 0.017453292f * unk14C);
+	PSMTXConcat(model->getBaseTRMtx(), temp, model->getBaseTRMtx());
+}
+
+void TBellDolpic::ring(const JGeometry::TVec3<f32>& pos)
+{
+	f32 _pad[2];
+	(void)_pad;
+	JGeometry::TVec3<f32> diff;
+
+	if (fabsf(unk150) > 0.01f)
+		return;
+	diff = mPosition;
+	diff.x -= pos.x;
+	diff.y -= pos.y;
+	diff.z -= pos.z;
+	diff.y = 0.0f;
+
+	if (!sInitRing) {
+		sUpRing.x = 0.0f;
+		sUpRing.y = 1.0f;
+		sUpRing.z = 0.0f;
+		sInitRing = true;
+	}
+
+	f32 dy = diff.y;
+	f32 uz = sUpRing.z;
+	f32 ux = sUpRing.x;
+	f32 dz = diff.z;
+	f32 uy = sUpRing.y;
+	f32 dx = diff.x;
+	unk140 = uy * dz - uz * dy;
+	unk144 = uz * dx - ux * dz;
+	unk148 = ux * dy - uy * dx;
+
+	f32 lenSq = unk140 * unk140 + unk144 * unk144 + unk148 * unk148;
+	if (lenSq <= 0.0000038146973f) {
+		unk140 = 1.0f;
+		unk144 = 0.0f;
+		unk148 = 0.0f;
+	} else {
+		PSVECNormalize((Vec*)&unk140, (Vec*)&unk140);
+	}
+
+	unk150 -= 0.5f;
+
+	int r = rand();
+	f32 tmp = (f32)r * 0.000030517578f;
+	unk158 = (int)(tmp * 14400.0f) + 0x5460;
+}
+
+void TBellDolpic::touchPlayer(THitActor* actor)
+{
+	ring(actor->mPosition);
+}
+
+BOOL TBellDolpic::receiveMessage(THitActor* sender, u32 message)
+{
+	f32 _pad[2];
+	(void)_pad;
+
+	if (sender->isActorTypeOf(0x80000000)) {
+		ring(sender->mPosition);
+	}
+
+	if (sender->isActorTypeOf(0x01000000)) {
+		gpMarioParticleManager->emit(0xE7, &sender->mPosition, 0, nullptr);
+
+		if (unk154 == 0)
+			return 1;
+
+		unk154 = unk154 - 1;
+
+		unk138.a = (u8)(unk154 * 100 / 1000);
+
+		if (unk154 == 0) {
+			if (unk13C == 0) {
+				gpItemManager->makeShineAppearWithDemo(
+				    "\x83\x56\x83\x83\x83\x43\x83\x93\x81\x69\x83\x68\x83\x8B\x83\x73\x83\x62\x83\x4E\x8F\xE0\x8C\x78\x8E\x40\x8F\x90\x97\x70\x81\x6A",
+				    "\x83\x68\x83\x8B\x83\x73\x83\x62\x83\x4E\x8F\xE0\x8C\x78\x8E\x40\x8F\x90\x83\x4A\x83\x81\x83\x89",
+				    mPosition.x, mPosition.y, mPosition.z);
+			} else {
+				gpItemManager->makeShineAppearWithDemo(
+				    "\x83\x56\x83\x83\x83\x43\x83\x93\x81\x69\x83\x68\x83\x8B\x83\x73\x83\x62\x83\x4E\x8F\xE0\x83\x65\x83\x83\x83\x8C\x83\x72\x8B\xC7\x97\x70\x81\x6A",
+				    "\x83\x68\x83\x8B\x83\x73\x83\x62\x83\x4E\x8F\xE0\x83\x65\x83\x83\x83\x8C\x83\x72\x8B\xC7\x83\x4A\x83\x81\x83\x89",
+				    mPosition.x, mPosition.y, mPosition.z);
+			}
+
+			if (gpMSound->gateCheck(0x484A)) {
+				MSoundSESystem::MSoundSE::startSoundSystemSE(0x484A, 0, nullptr, 0);
+			}
+		}
+
+		return 1;
+	}
+
+	return 0;
+}
+
+void TBellDolpic::control()
+{
+	JGeometry::TVec3<f32> pos;
+	f32 _pad[8];
+	(void)_pad;
+
+	if (unk154 == 0) {
+		if (unk158 == 0) {
+			pos = mPosition;
+			pos.z += 100.0f;
+			ring(pos);
+		} else {
+			unk158 = unk158 - 1;
+		}
+	}
+
+	TMapObjBase::control();
+
+	f32 sinVal = -JMASin(unk14C);
+	unk150 = 0.01f * sinVal + unk150;
+
+	unk14C = unk14C + unk150;
+
+	if (unk14C < -30.0f || unk14C > 30.0f) {
+		unk150 = -unk150;
+
+		if (unk154 == 0) {
+			if (unk15C) {
+				if (gpMSound->gateCheck(0x38A5)) {
+					MSoundSESystem::MSoundSE::startSoundActor(0x38A5, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+				}
+			} else {
+				if (gpMSound->gateCheck(0x38A6)) {
+					MSoundSESystem::MSoundSE::startSoundActor(0x38A6, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+				}
+			}
+		} else {
+			if (unk15C) {
+				if (gpMSound->gateCheck(0x38A8)) {
+					MSoundSESystem::MSoundSE::startSoundActor(0x38A8, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+				}
+			} else {
+				if (gpMSound->gateCheck(0x38A9)) {
+					MSoundSESystem::MSoundSE::startSoundActor(0x38A9, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+				}
+			}
+		}
+
+		unk15C ^= 1;
+	}
+
+	unk150 = unk150 * 0.9995f;
+}
+
+// TDptMonteFence
+
+void TDptMonteFence::touchPlayer(THitActor* actor)
+{
+	f32 _pad[4];
+	(void)_pad;
+
+	if (SMS_IsMarioStatusThrownDown()) {
+		if (gpMSound->gateCheck(0x380A)) {
+			MSoundSESystem::MSoundSE::startSoundActor(0x380A, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+		}
+		if (gpMSound->gateCheck(0x3857)) {
+			MSoundSESystem::MSoundSE::startSoundActor(0x3857, (const Vec*)&mPosition, 0, nullptr, 0, 4);
+		}
+		kill();
+	}
+}
+
+// TMapObjSmoke
+
+u32 TMapObjSmoke::touchWater(THitActor* actor)
+{
+	appearObj(100.0f);
+	makeObjDead();
+	return 1;
+}
+
+void TMapObjSmoke::control()
+{
+	emitAndRotateScale(0x152, 1, (const JGeometry::TVec3<f32>*)&mPosition);
+}
+
+void TMapObjSmoke::load(JSUMemoryInputStream& in)
+{
+	THideObjBase::load(in);
+	SMS_LoadParticle("/scene/mapObj/ms_map_kokuen.jpa", 0x152);
+}
+
+// TMareGate
+
+void TMareGate::control()
+{
+	f32 _pad[2];
+	(void)_pad;
+
+	TMapObjBase::control();
+	MSound* sound = gpMSound;
+	if (sound->gateCheck(0x3085)) {
+		MSoundSESystem::MSoundSE::startSoundActor(0x3085, (const Vec*)&mPosition, 0, (JAISound**)&sound->unk7C, 0, 4);
+	}
+}
+
+void TMareGate::loadAfter()
+{
+	TMapObjBase::loadAfter();
+	if (!TFlagManager::smInstance->getBool(0x50004)) {
+		makeObjDead();
+	}
+}
+
+// TDemoCannon
+
+void TDemoCannon::loadAfter()
+{
+	SMS_LoadParticle("/scene/mapObj/demoCannon_a.jpa", 232);
+	SMS_LoadParticle("/scene/mapObj/demoCannon_b.jpa", 233);
+	SMS_LoadParticle("/scene/mapObj/demoCannon_c.jpa", 234);
+	SMS_LoadParticle("/scene/mapObj/demoCannon_d.jpa", 235);
+	SMS_LoadParticle("/scene/mapObj/demoCannon_e.jpa", 236);
+	SMS_LoadParticle("/scene/mapObj/demoCannon_smoke.jpa", 358);
+}
+
+void TDemoCannon::initMapObj()
+{
+	f32 _pad[2];
+	(void)_pad;
+
+	TMapObjBase::initMapObj();
+
+	mMActor->setBck("democannon_dpt");
+	J3DFrameCtrl* frameCtrl = mMActor->getFrameCtrl(0);
+	frameCtrl->mCurrentFrame = (f32)frameCtrl->mEndFrame;
+
+	void* res = JKRFileLoader::getGlbResource("/scene/mapObj/demoCannon_dom.bmd");
+	SDLModelData* sdlData = new SDLModelData(J3DModelLoaderDataBase::load(res, 0x10050000));
+
+	JUTNameTab* jointName = mMActor->getModel()->getModelData()->getJointName();
+
+	TSharedParts* parts = new TSharedParts(this, jointName->getIndex("nullA"), sdlData, 3, "<TSharedParts>");
+	unk138 = parts;
+
+	res = JKRFileLoader::getGlbResource("/scene/mapObj/demoCannon_mario.bmd");
+	SDLModelData* sdlData2 = new SDLModelData(J3DModelLoaderDataBase::load(res, 0x10010000));
+
+	parts = new TSharedParts(this, 0, sdlData2, 3, "<TSharedParts>");
+	unk13C = parts;
+}
+
+void TDemoCannon::startDemo()
+{
+	unk14C = 1;
+
+	MSound* sound = gpMSound;
+	s16 hp = SMS_GetMarioHP();
+	sound->startMarioVoice(30911, hp, 0);
+
+	mMActor->setBck("democannon_dpt");
+	unk138->getMActor()->setBck("democannon_dom");
+	unk13C->getMActor()->setBck("democannon_mario_fly1");
+}
+
+void TDemoCannon::perform(u32 flags, JDrama::TGraphics* gfx)
+{
+	f32 _pad1[3];
+	volatile f32 f;
+	f32 _pad2[10];
+	(void)_pad1; (void)_pad2;
+
+	TMapObjBase::perform(flags, gfx);
+
+	if (!unk14C)
+		return;
+
+	unk138->perform(flags, gfx);
+	unk13C->getMActor()->perform(flags, gfx);
+
+	if (!(flags & 2))
+		return;
+
+	J3DFrameCtrl* frameCtrl = unk13C->getMActor()->getFrameCtrl(0);
+	if (frameCtrl->mCurrentFrame < 174.0f) {
+		if (gpMSound->gateCheck(8392))
+			MSoundSESystem::MSoundSE::startSoundActor(8392, &mPosition, 0, nullptr, 0, 4);
+	}
+
+	frameCtrl = unk13C->getMActor()->getFrameCtrl(0);
+	if (frameCtrl->checkPass(174.0f)) {
+		gpCameraShake->startShake((EnumCamShakeMode)36, 1.0f);
+		SMSRumbleMgr->start(21, 10, (f32*)0);
+
+		Mtx* mtx = unk138->getMActor()->getModel()->mNodeMatrices;
+
+		gpMarioParticleManager->emitAndBindToMtxPtr(232, (MtxPtr)mtx, 0, nullptr);
+		gpMarioParticleManager->emitAndBindToMtxPtr(233, (MtxPtr)mtx, 0, nullptr);
+		gpMarioParticleManager->emitAndBindToMtxPtr(234, (MtxPtr)mtx, 0, nullptr);
+		gpMarioParticleManager->emitAndBindToMtxPtr(235, (MtxPtr)mtx, 0, nullptr);
+		gpMarioParticleManager->emitAndBindToMtxPtr(236, (MtxPtr)mtx, 0, nullptr);
+
+		if (gpMSound->gateCheck(10574))
+			MSoundSESystem::MSoundSE::startSoundActor(10574, &mPosition, 0, nullptr, 0, 4);
+		if (gpMSound->gateCheck(10605))
+			MSoundSESystem::MSoundSE::startSoundActor(10605, &mPosition, 0, nullptr, 0, 4);
+	}
+
+	frameCtrl = unk13C->getMActor()->getFrameCtrl(0);
+	if (frameCtrl->mCurrentFrame > 175.0f) {
+		Mtx* mtx = unk13C->getMActor()->getModel()->mNodeMatrices;
+		gpMarioParticleManager->emitAndBindToMtxPtr(358, (MtxPtr)mtx, 1, this);
+	}
+}
+
+// TTurboNozzleDoor
+
+void TTurboNozzleDoor::loadAfter()
+{
+	f32 _pad[8];
+	(void)_pad;
+
+	if (strcmp("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x4f", mName) == 0) {
+		JDrama::TNameRef* root = JDrama::TNameRefGen::getInstance()->getRootNameRef();
+		unk144 = (TLiveActor*)root->searchF(JDrama::TNameRef::calcKeyCode("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x50"), "\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x50");
+	} else if (strcmp("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x50", mName) == 0) {
+		JDrama::TNameRef* root = JDrama::TNameRefGen::getInstance()->getRootNameRef();
+		unk144 = (TLiveActor*)root->searchF(JDrama::TNameRef::calcKeyCode("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x4f"), "\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x60\x82\x4f");
+	} else if (strcmp("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x4f", mName) == 0) {
+		JDrama::TNameRef* root = JDrama::TNameRefGen::getInstance()->getRootNameRef();
+		unk144 = (TLiveActor*)root->searchF(JDrama::TNameRef::calcKeyCode("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x50"), "\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x50");
+	} else if (strcmp("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x50", mName) == 0) {
+		JDrama::TNameRef* root = JDrama::TNameRefGen::getInstance()->getRootNameRef();
+		unk144 = (TLiveActor*)root->searchF(JDrama::TNameRef::calcKeyCode("\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x4f"), "\x8b\xf3\x8d\x60\x83\x68\x83\x41\x82\x61\x82\x4f");
+	}
+}
+
+void TTurboNozzleDoor::touchPlayer(THitActor* player)
+{
+	if (!SMS_IsMarioDashing())
+		return;
+
+	if (gpMarDirector->mMap == 1) {
+		startBck("nozzledoor");
+	} else {
+		makeObjDead();
+		((TMapObjBase*)unk144)->makeObjDead();
+	}
+
+	if (gpMSound->gateCheck(14346))
+		MSoundSESystem::MSoundSE::startSoundActor(14346, &mPosition, 0, nullptr, 0, 4);
+	if (gpMSound->gateCheck(14423))
+		MSoundSESystem::MSoundSE::startSoundActor(14423, &mPosition, 0, nullptr, 0, 4);
+
+	JGeometry::TVec3<f32> scale;
+	f32 _pad[8];
+	(void)_pad;
+
+	scale.x = 1.3f;
+	scale.y = 1.3f;
+	scale.z = 1.3f;
+
+	f32 yOff = 100.0f;
+	unk138.x = mPosition.x;
+	unk138.y = yOff + mPosition.y;
+	unk138.z = mPosition.z;
+
+	emitAndScale(24, 0, &unk138, scale);
+	emitAndScale(25, 0, &unk138, scale);
+	emitAndScale(57, 0, &unk138, scale);
+
+	removeMapCollision();
+	unk64 |= 1;
+}
+
+TTurboNozzleDoor::~TTurboNozzleDoor() { }


### PR DESCRIPTION
## Summary
- Decompile MapObjDolpic.cpp: TMonumentShine, TBellDolpic, TDptMonteFence, TMapObjSmoke, TMareGate, TDemoCannon, TTurboNozzleDoor
- Add `isActorTypeOf()` inline helper to THitActor for boolean materialization matching