### PR TITLE
Refactor SMS_EmitSinkInPollutionEffect vector normalization

### DIFF
--- a/src/MarioUtil/EffectUtil.cpp
+++ b/src/MarioUtil/EffectUtil.cpp
@@ -50,32 +50,31 @@ void SMS_EmitSinkInPollutionEffect(const JGeometry::TVec3<float>& arg0,
 {
 	if ((gpMarDirector->unk58 % 20) != 0)
 		return;
-
+    
 	using namespace JGeometry;
-
+    
 	const TVec3<f32> fwd(1.f, 0.0f, 0.0f);
 
 	TVec3<f32> B;
 	B.cross(fwd, arg1);
 
-	TPosition3f matrix;
-
 	TVec3<f32> C;
 	C.cross(arg1, B);
-	TVec3<f32> Cnorm;
-	Cnorm.normalize(C);
-	TVec3<f32> Bnorm;
-	Bnorm.normalize(B);
 
-	matrix.mMtx[0][0] = Cnorm.x;
-	matrix.mMtx[1][0] = Cnorm.y;
-	matrix.mMtx[2][0] = Cnorm.z;
+    C.normalize();
+    B.normalize();
+
+	TPosition3f matrix;
+
+	matrix.mMtx[0][0] = C.x;
+	matrix.mMtx[1][0] = C.y;
+	matrix.mMtx[2][0] = C.z;
 	matrix.mMtx[0][1] = arg1.x;
 	matrix.mMtx[1][1] = arg1.y;
 	matrix.mMtx[2][1] = arg1.z;
-	matrix.mMtx[0][2] = Bnorm.x;
-	matrix.mMtx[1][2] = Bnorm.y;
-	matrix.mMtx[2][2] = Bnorm.z;
+	matrix.mMtx[0][2] = B.x;
+	matrix.mMtx[1][2] = B.y;
+	matrix.mMtx[2][2] = B.z;
 	matrix.mMtx[0][3] = arg0.x;
 	matrix.mMtx[1][3] = arg0.y;
 	matrix.mMtx[2][3] = arg0.z;


### PR DESCRIPTION
Improved match on SMS_EmitSinkInPollutionEffect. 
Removed temps, and just normalized C and B.