### PR TITLE
MarioRecord full match.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -916,7 +916,7 @@ config.libs = [
             Object(NonMatching, "Player/MarioMain.cpp"),
             Object(NonMatching, "Player/MarioMove.cpp"),
             Object(NonMatching, "Player/MarioPhysics.cpp"),
-            Object(NonMatching, "Player/MarioRecord.cpp"),
+            Object(Matching, "Player/MarioRecord.cpp"),
             Object(NonMatching, "Player/MarioRun.cpp"),
             Object(NonMatching, "Player/MarioSpecial.cpp"),
             Object(NonMatching, "Player/MarioUpper.cpp"),

--- a/include/Player/MarioRecord.hpp
+++ b/include/Player/MarioRecord.hpp
@@ -1,0 +1,42 @@
+#ifndef MARIORECORD_HPP
+#define MARIORECORD_HPP
+
+#include <dolphin/types.h>
+
+template <typename T> class TRecordValueManager {
+public:
+	void reset();
+	bool get(T* outValue);
+
+public:
+	u32* mFirstDurationPtr;   // 0x0
+	T* mFirstValuePtr;        // 0x4
+	u32* mCurrentDurationPtr; // 0x8
+	T* mCurrentValuePtr;      // 0xC
+	s32 mElapsedFrames;       // 0x10
+	s32 mUnk14;               // 0x14
+	s32 mUnk18;               // 0x18
+};
+
+class TMarioInputReplay {
+public:
+	void init(u8* iData);
+	bool play(f32* outIntendedMag, s16* outIntendedYaw, u32* outPressedBtns,
+	          u32* outJustPressedBtns, u8*, u8*);
+	void reset();
+
+private:
+	s16 mUnk0;                         // 0x0
+	u16 mCanPlay;                      // 0x2
+	u16 mPrevBtnMask;                  // 0x4
+	s16 mUnk6;                         // 0x6
+	u32 mReplayPos;                    // 0x8
+	u32 mReplayLength;                 // 0xC
+	TRecordValueManager<f32> mMag;     // 0x10
+	TRecordValueManager<s16> mYaw;     // 0x2C
+	TRecordValueManager<u16> mBtnMask; // 0x48
+	TRecordValueManager<u8> mUnk64;    // 0x64
+	TRecordValueManager<u8> mUnk80;    // 0x80
+};
+
+#endif // MARIORECORD_HPP

--- a/src/Player/MarioRecord.cpp
+++ b/src/Player/MarioRecord.cpp
@@ -1,1 +1,108 @@
+#include <Player/MarioRecord.hpp>
 
+template <typename T> bool TRecordValueManager<T>::get(T* outValue)
+{
+	*outValue = *mCurrentValuePtr;
+	mElapsedFrames++;
+
+	if (mElapsedFrames >= *mCurrentDurationPtr) {
+		mCurrentDurationPtr++;
+		mCurrentValuePtr++;
+		mElapsedFrames = 0;
+		return true;
+	}
+	return false;
+}
+
+template <typename T> void TRecordValueManager<T>::reset()
+{
+	mCurrentDurationPtr = mFirstDurationPtr;
+	mCurrentValuePtr    = mFirstValuePtr;
+	mElapsedFrames      = 0;
+	mUnk14              = 0;
+}
+
+void TMarioInputReplay::init(u8* iData)
+{
+	mUnk0        = 0;
+	mCanPlay     = 0;
+	mPrevBtnMask = 0;
+	mReplayPos   = 0;
+
+	s32 offset = 0x10;
+
+	mReplayLength = *reinterpret_cast<s32*>(iData + offset);
+
+	offset += 4;
+	mMag.mFirstDurationPtr = (u32*)(iData + *(s32*)(iData + offset));
+	offset += 4;
+	mMag.mFirstValuePtr = (f32*)(iData + *(s32*)(iData + offset));
+	mMag.reset();
+
+	offset += 4;
+	mYaw.mFirstDurationPtr = (u32*)(iData + *(s32*)(iData + offset));
+	offset += 4;
+	mYaw.mFirstValuePtr = (s16*)(iData + *(s32*)(iData + offset));
+	mYaw.reset();
+
+	offset += 4;
+	mBtnMask.mFirstDurationPtr = (u32*)(iData + *(s32*)(iData + offset));
+	offset += 4;
+	mBtnMask.mFirstValuePtr = (u16*)(iData + *(s32*)(iData + offset));
+	mBtnMask.reset();
+
+	offset += 4;
+	mUnk64.mFirstDurationPtr = (u32*)(iData + *(s32*)(iData + offset));
+	offset += 4;
+	mUnk64.mFirstValuePtr = (u8*)(iData + *(s32*)(iData + offset));
+	mUnk64.reset();
+
+	offset += 4;
+	mUnk80.mFirstDurationPtr = (u32*)(iData + *(s32*)(iData + offset));
+	offset += 4;
+	mUnk80.mFirstValuePtr = (u8*)(iData + *(s32*)(iData + offset));
+	mUnk80.reset();
+}
+
+bool TMarioInputReplay::play(f32* outIntendedMag, s16* outIntendedYaw,
+                             u32* outBtnMask, u32* outJustPressedBtnMask,
+                             u8* outParam5, u8* outParam6)
+{
+	if (mCanPlay == 1) {
+		if (mReplayPos < mReplayLength) {
+			mMag.get(outIntendedMag);
+			mYaw.get(outIntendedYaw);
+
+			u16 btnMask;
+			mBtnMask.get(&btnMask);
+
+			u16 justPressedBtns = btnMask & (btnMask ^ mPrevBtnMask);
+			mPrevBtnMask        = btnMask;
+
+			*outBtnMask = (*outBtnMask & 0xFFFF0000) | btnMask;
+			*outJustPressedBtnMask
+			    = justPressedBtns | (*outJustPressedBtnMask & 0xFFFF0000);
+
+			mUnk64.get(outParam5);
+			mUnk80.get(outParam6);
+
+			mReplayPos++;
+			return true;
+		}
+		mCanPlay = 0;
+	}
+	return false;
+}
+
+void TMarioInputReplay::reset()
+{
+	mCanPlay     = 0;
+	mPrevBtnMask = 0;
+	mReplayPos   = 0;
+
+	mMag.reset();
+	mYaw.reset();
+	mBtnMask.reset();
+	mUnk64.reset();
+	mUnk80.reset();
+}


### PR DESCRIPTION
I've been trying to name all the members in ways that hopefully reflect how they are being used from context clues. (Mostly searching for method callsites in Ghidra.) However, a few members I am not sure what exactly they store or may only be used in inlines elsewhere, so I left these as unknowns.

As the name suggets, I believe that `TMarioInputReplay` simply replays prerecorded inputs.

`TMarioInputReplay` processes replay data for five different inputs: "magnitude", "yaw" (for `TMario::mIntendedMag` and `TMario::mIntendedYaw`), a button mask (I believe these are buttons at least), and two unknown inputs.

Inputs are loaded from `.pad` files. (See `TEnemyMario::initEnemyValues` (shadow mario?).)
The structure of a `.pad` file should look something like this:

| Offset | Type | Content |
| --- | --- | --- |
| 0x0 | ??  | Header Data |
| 0x10 | s32 | Replay Length |
| 0x14 | s32 | Byte offset to “magnitude” duration data. |
| 0x18 | s32 | Byte offset to “magnitude” value data. |
| 0x22 | s32 | Byte offset to “yaw” duration data. |
| 0x26 | s32 | Byte offset to “yaw” value data. |
| 0x30 | s32 | Byte offset to button mask duration data. |
| 0x34 | s32 | Byte offset to button mask value data. |
| 0x38 | s32 | Byte offset to unknown duration data. |
| 0x42 | s32 | Byte offset to unknown value data. |
| 0x46 | s32 | Byte offset to unknown duration data. |
| 0x50 | s32 | Byte offset to unknown value data. |

The header is 16 bytes long and skipped by the code, so I'm not sure what it contains.

Address 0x10 is the first useful piece of data and contains the length of the replay in frames.

Duration data is an `u32` array. Each value encodes how many frames an input is repeated. 
Value data is an array with a specific type for each input. Each value encodes e.g. the yaw angle or a button mask.

| Value | Type |
| --- | --- |
| Magnitude | `f32` |
| Yaw | `s16` |
| Button Mask | `u16` |
| Unknown | `u8` |

Since inputs may repeat over multiple frames (as determined by the duration data), the length of the duration and value arrays does _not_ necessarily match the replay length.