### PR TITLE
Improve matching: cameralib signature/return fixes, enemy decl/assign…

### DIFF
--- a/include/Camera/cameralib.hpp
+++ b/include/Camera/cameralib.hpp
@@ -5,7 +5,7 @@
 
 extern f32 SMSGetAnmFrameRate(); // avoid including Application.hpp
 
-void CLBCalc2DFPos(JGeometry::TVec2<f32>*, const MtxPtr, const MtxPtr,
+void CLBCalc2DFPos(JGeometry::TVec2<f32>*, const f32 (*)[4], const f32 (*)[4],
                    const Vec&, u32*, bool);
 
 void CLBCalcNearClipAngle(JGeometry::TVec3<f32>*, S16Vec*,
@@ -69,7 +69,7 @@ bool CLBChaseAngleDecrease(s16* out, s16 target, s16 invSpeed);
  */
 BOOL CLBChaseDecrease(f32* dstValue, f32 targetValue, f32 ratio, f32 threshold);
 
-bool CLBChaseSpecialDecrease(f32*, f32, f32, f32);
+BOOL CLBChaseSpecialDecrease(f32*, f32, f32, f32);
 
 /**
  * @brief Converts Cartesian coordinates to spherical coordinates.

--- a/src/Camera/cameralib.cpp
+++ b/src/Camera/cameralib.cpp
@@ -9,6 +9,8 @@
 static const f32 SHORTANGLE_TO_DEGREES = 0.005493164f; // 360/65536
 static const f32 DEGREES_TO_RADIANS    = 0.017453294f; // pi/180
 
+JGeometry::TVec3<f32> CLBConstUpVec(0.0f, 1.0f, 0.0f);
+
 // TODO: Almost definitely fake, this is probably inlined somewhere else
 static inline f32 fastSqrt(f32 x)
 {
@@ -38,8 +40,8 @@ static inline void RotateAboutAxis(const JGeometry::TVec3<f32>& param_axis,
 }
 
 // TODO: Explore how this is used, and add documentation
-void CLBCalc2DFPos(JGeometry::TVec2<f32>* param_1, MtxPtr param_2,
-                   const MtxPtr param_3, const Vec& param_4, u32* param_5,
+void CLBCalc2DFPos(JGeometry::TVec2<f32>* param_1, const f32 (*param_2)[4],
+                   const f32 (*param_3)[4], const Vec& param_4, u32* param_5,
                    bool param_6)
 {
 	Vec prod;
@@ -322,8 +324,8 @@ BOOL CLBChaseDecrease(f32* dstValue, f32 targetValue, f32 ratio, f32 threshold)
 	}
 }
 
-bool CLBChaseSpecialDecrease(f32* param_1, f32 param_2, f32 param_3,
-                             f32 param_4)
+BOOL CLBChaseSpecialDecrease(f32* param_1, f32 param_2, f32 param_3,
+                              f32 param_4)
 {
 	if (param_3 > 1.0f) {
 		param_3 = 1.0f;

--- a/src/Enemy/enemy.cpp
+++ b/src/Enemy/enemy.cpp
@@ -581,7 +581,8 @@ void TSpineEnemy::doShortCut()
 		return;
 	}
 
-	TPathNode node = unk114.pop();
+	TPathNode node;
+	node = unk114.pop();
 
 	JGeometry::TVec3<f32> local_28 = node.getPoint() - mPosition;
 	if (local_28.x == 0.0f && local_28.y == 0.0f && local_28.z == 0.0f)

--- a/src/Enemy/fireWanwan.cpp
+++ b/src/Enemy/fireWanwan.cpp
@@ -1184,6 +1184,7 @@ void TFireWanwan::updateCollisionFromParam()
 	             getSaveParam2()->mSLDamageHeight.get());
 }
 
+#pragma dont_inline on
 // Tiny size mismatch
 void TFireWanwan::updateCameraShake()
 {
@@ -1215,6 +1216,7 @@ void TFireWanwan::updateRumble()
 		mHungTailRumbleTimer = 0;
 	}
 }
+#pragma dont_inline off
 
 void TFireWanwan::updatePollute()
 {


### PR DESCRIPTION
…, fireWanwan pragma

- cameralib.hpp: Fix CLBCalc2DFPos signature, CLBChaseSpecialDecrease return bool->BOOL
- cameralib.cpp: Fix CLBCalc2DFPos signature (missing->98.2%), add CLBConstUpVec global (__sinit missing->100%), fix CLBChaseSpecialDecrease return type (87.5%->100%)
- enemy.cpp: Split TPathNode decl/assign in doShortCut (94.7%->96.0%)
- fireWanwan.cpp: Add #pragma dont_inline around updateCameraShake/updateRumble for moveObject (73.6%->84.6%)