### PR TITLE
Match TAmbColor::JSGSetColor

### DIFF
--- a/src/JSystem/JDrama/JDRLighting.cpp
+++ b/src/JSystem/JDrama/JDRLighting.cpp
@@ -128,7 +128,11 @@ void TAmbColor::perform(u32 param_1, TGraphics* param_2)
 
 GXColor TAmbColor::JSGGetColor() const { return mColor; }
 
-void TAmbColor::JSGSetColor(GXColor color) { mColor = color; }
+void TAmbColor::JSGSetColor(GXColor color)
+{
+	volatile u32 unused[2];
+	mColor = color;
+}
 
 void TAmbAry::load(JSUMemoryInputStream& stream)
 {


### PR DESCRIPTION
Matches `TAmbColor::JSGSetColor` (`JSGSetColor__Q26JDrama9TAmbColorF8_GXColor`) in `src/JSystem/JDrama/JDRLighting.cpp` to 100%.

The original reserves a `0x30` stack frame while our source produced `0x28`. The instruction bodies were already identical; only the frame size differed by 8 bytes. Adding an unused `volatile` local reproduces the missing stack space, giving a byte-identical match.

Verified with objdiff (`GMSJ01`): the function reports 100% and the full build still produces `mario.dol: OK`.