### PR TITLE
Match TControl::volFloatToU8

### DIFF
--- a/src/JSystem/JAudio/JASystem/JASHardStream.cpp
+++ b/src/JSystem/JAudio/JASystem/JASHardStream.cpp
@@ -467,6 +467,7 @@ namespace HardStream {
 
 	u8 TControl::volFloatToU8(f32 param_1)
 	{
+		volatile u32 unused[2];
 		if (param_1 > 1.0f)
 			param_1 = 1.0f;
 


### PR DESCRIPTION
Matches `TControl::volFloatToU8` (`volFloatToU8__Q38JASystem10HardStream8TControlFf`) in `src/JSystem/JAudio/JASystem/JASHardStream.cpp` to 100%.

The original reserves a `0x20` stack frame while our source produced `0x18`. The instruction bodies were already identical; only the frame size differed by 8 bytes. Adding an unused `volatile` local reproduces the missing stack space, giving a byte-identical match.

Verified with objdiff (`GMSJ01`): the function reports 100% and the full build still produces `mario.dol: OK`.