### PR TITLE
Match TAnimalBase ctor, receiveMessage, calcRootMatrix

### DIFF
--- a/include/Animal/AnimalBase.hpp
+++ b/include/Animal/AnimalBase.hpp
@@ -18,6 +18,7 @@ public:
 	                         const JGeometry::TVec3<f32>&, f32, f32);
 	void resetRandomCurPathNode();
 	void loadAfter();
+	void initNoLoad_(TAnimalBase*);
 
 public:
 	/* 0x150 */ int* mFrameTimer;

--- a/include/Animal/AnimalBase.hpp
+++ b/include/Animal/AnimalBase.hpp
@@ -25,9 +25,8 @@ public:
 	virtual void calcRootMatrix();
 
 	void execWalk(bool);
-	static void
-	getRotationFlyToDir(JGeometry::TVec3<f32>*, const JGeometry::TVec3<f32>&,
-	                    f32, f32);
+	static void getRotationFlyToDir(JGeometry::TVec3<f32>*,
+	                                const JGeometry::TVec3<f32>&, f32, f32);
 	void resetRandomCurPathNode();
 	void loadAfter();
 	void initNoLoad_(TAnimalBase*);

--- a/include/Animal/AnimalBase.hpp
+++ b/include/Animal/AnimalBase.hpp
@@ -25,7 +25,7 @@ public:
 	virtual void calcRootMatrix();
 
 	void execWalk(bool);
-	static JGeometry::TVec3<f32>
+	static void
 	getRotationFlyToDir(JGeometry::TVec3<f32>*, const JGeometry::TVec3<f32>&,
 	                    f32, f32);
 	void resetRandomCurPathNode();
@@ -39,5 +39,4 @@ public:
 public:
 	/* 0x150 */ int* mFrameTimer;
 };
-
 #endif

--- a/include/Animal/AnimalBase.hpp
+++ b/include/Animal/AnimalBase.hpp
@@ -6,7 +6,6 @@
 class TAnimalBase : public TSpineEnemy {
 public:
 	TAnimalBase(u32, const char* name = "?");
-	virtual ~TAnimalBase();
 
 	virtual void load(JSUMemoryInputStream&);
 	virtual void perform(u32, JDrama::TGraphics*);
@@ -20,6 +19,10 @@ public:
 	void resetRandomCurPathNode();
 	void loadAfter();
 	void initNoLoad_(TAnimalBase*);
+
+	// UNUSED (fully inlined in the original; present in mario.MAP)
+	void animalWalkIn();
+	void flyToCurPathNode(f32, f32);
 
 public:
 	/* 0x150 */ int* mFrameTimer;

--- a/include/Animal/AnimalBase.hpp
+++ b/include/Animal/AnimalBase.hpp
@@ -6,6 +6,7 @@
 class TAnimalBase : public TSpineEnemy {
 public:
 	TAnimalBase(u32, const char* name = "?");
+	virtual ~TAnimalBase();
 
 	virtual void load(JSUMemoryInputStream&);
 	virtual void perform(u32, JDrama::TGraphics*);

--- a/include/Animal/AnimalBase.hpp
+++ b/include/Animal/AnimalBase.hpp
@@ -14,8 +14,9 @@ public:
 	virtual void calcRootMatrix();
 
 	void execWalk(bool);
-	void getRotationFlyToDir(JGeometry::TVec3<f32>*,
-	                         const JGeometry::TVec3<f32>&, f32, f32);
+	JGeometry::TVec3<f32> getRotationFlyToDir(JGeometry::TVec3<f32>*,
+	                                          const JGeometry::TVec3<f32>&, f32,
+	                                          f32);
 	void resetRandomCurPathNode();
 	void loadAfter();
 	void initNoLoad_(TAnimalBase*);

--- a/include/Animal/AnimalBase.hpp
+++ b/include/Animal/AnimalBase.hpp
@@ -3,6 +3,17 @@
 
 #include <Enemy/Enemy.hpp>
 
+struct TAnimalBaseUnk150 {
+	TAnimalBaseUnk150()
+	{
+		unk0 = 0;
+		unk4 = 1;
+	}
+
+	int unk0;
+	int unk4;
+};
+
 class TAnimalBase : public TSpineEnemy {
 public:
 	TAnimalBase(u32, const char* name = "?");

--- a/include/Animal/AnimalBase.hpp
+++ b/include/Animal/AnimalBase.hpp
@@ -14,9 +14,9 @@ public:
 	virtual void calcRootMatrix();
 
 	void execWalk(bool);
-	JGeometry::TVec3<f32> getRotationFlyToDir(JGeometry::TVec3<f32>*,
-	                                          const JGeometry::TVec3<f32>&, f32,
-	                                          f32);
+	static JGeometry::TVec3<f32>
+	getRotationFlyToDir(JGeometry::TVec3<f32>*, const JGeometry::TVec3<f32>&,
+	                    f32, f32);
 	void resetRandomCurPathNode();
 	void loadAfter();
 	void initNoLoad_(TAnimalBase*);

--- a/include/Animal/boid.hpp
+++ b/include/Animal/boid.hpp
@@ -1,0 +1,62 @@
+#ifndef ANIMAL_BOID_HPP
+#define ANIMAL_BOID_HPP
+
+#include <JSystem/JDrama/JDRViewObj.hpp>
+#include <JSystem/JGeometry.hpp>
+
+class TGraphWeb;
+class TBoid;
+
+class TBoidLeader : public JDrama::TViewObj {
+public:
+	TBoidLeader(int, const char*);
+
+	virtual ~TBoidLeader();
+	virtual void perform(u32, JDrama::TGraphics*);
+
+	void calcForces(const TBoid*) const;
+	JGeometry::TVec3<f32> calcGoalForce(const JGeometry::TVec3<f32>&) const;
+	void setGraph(TGraphWeb*, const JGeometry::TVec3<f32>&);
+	void calcBoids();
+
+public:
+	/* 0x10 */ int mNumBoids;
+	/* 0x14 */ TBoid* mBoids;
+	/* 0x18 */ s32 unk18;
+	/* 0x1C */ u32 unk1C;
+	/* 0x20 */ f32 unk20;
+	/* 0x24 */ f32 unk24;
+	/* 0x28 */ f32 unk28;
+	/* 0x2C */ f32 unk2C;
+	/* 0x30 */ f32 unk30;
+	/* 0x34 */ f32 unk34;
+	/* 0x38 */ s32 unk38;
+	/* 0x3C */ JGeometry::TVec3<f32> unk3C;
+	/* 0x48 */ f32 unk48;
+	/* 0x4C */ JGeometry::TVec3<f32> unk4C;
+	/* 0x58 */ s32 unk58;
+	/* 0x5C */ s32 unk5C;
+	/* 0x60 */ JGeometry::TVec3<f32> unk60;
+	/* 0x6C */ f32 unk6C;
+	/* 0x70 */ f32 unk70;
+	/* 0x74 */ f32 unk74;
+	/* 0x78 */ f32 unk78;
+	/* 0x7C */ f32 unk7C;
+};
+
+class TBoid {
+public:
+	TBoid();
+
+public:
+	/* 0x00 */ JGeometry::TVec3<f32> unk0;
+	/* 0x0C */ JGeometry::TVec3<f32> unkC;
+	/* 0x18 */ f32 unk18;
+	/* 0x1C */ f32 unk1C;
+	/* 0x20 */ f32 unk20;
+	/* 0x24 */ u8 unk24[0x48 - 0x24];
+	/* 0x48 */ s32 unk48;
+	/* 0x4C */ f32 unk4C;
+};
+
+#endif

--- a/include/Animal/boid.hpp
+++ b/include/Animal/boid.hpp
@@ -19,6 +19,7 @@ public:
 	JGeometry::TVec3<f32> calcGoalForce(const JGeometry::TVec3<f32>&) const;
 	void setGraph(TGraphWeb*, const JGeometry::TVec3<f32>&);
 	void calcBoids();
+	void updateGoal();
 
 public:
 	/* 0x10 */ int mNumBoids;

--- a/include/Animal/boid.hpp
+++ b/include/Animal/boid.hpp
@@ -2,6 +2,7 @@
 #define ANIMAL_BOID_HPP
 
 #include <Enemy/Graph.hpp>
+#include <Enemy/PathNode.hpp>
 #include <JSystem/JDrama/JDRViewObj.hpp>
 #include <JSystem/JGeometry.hpp>
 
@@ -30,8 +31,7 @@ public:
 	/* 0x2C */ f32 unk2C;
 	/* 0x30 */ f32 unk30;
 	/* 0x34 */ f32 unk34;
-	/* 0x38 */ s32 unk38;
-	/* 0x3C */ JGeometry::TVec3<f32> unk3C;
+	/* 0x38 */ TPathNode unk38;
 	/* 0x48 */ f32 unk48;
 	/* 0x4C */ JGeometry::TVec3<f32> unk4C;
 	/* 0x58 */ s32 unk58;

--- a/include/Animal/boid.hpp
+++ b/include/Animal/boid.hpp
@@ -1,10 +1,10 @@
 #ifndef ANIMAL_BOID_HPP
 #define ANIMAL_BOID_HPP
 
+#include <Enemy/Graph.hpp>
 #include <JSystem/JDrama/JDRViewObj.hpp>
 #include <JSystem/JGeometry.hpp>
 
-class TGraphWeb;
 class TBoid;
 
 class TBoidLeader : public JDrama::TViewObj {
@@ -22,7 +22,7 @@ public:
 public:
 	/* 0x10 */ int mNumBoids;
 	/* 0x14 */ TBoid* mBoids;
-	/* 0x18 */ s32 unk18;
+	/* 0x18 */ TGraphTracer* unk18;
 	/* 0x1C */ u32 unk1C;
 	/* 0x20 */ f32 unk20;
 	/* 0x24 */ f32 unk24;

--- a/include/Animal/boid.hpp
+++ b/include/Animal/boid.hpp
@@ -15,7 +15,7 @@ public:
 	virtual ~TBoidLeader();
 	virtual void perform(u32, JDrama::TGraphics*);
 
-	void calcForces(const TBoid*) const;
+	JGeometry::TVec3<f32> calcForces(const TBoid*) const;
 	JGeometry::TVec3<f32> calcGoalForce(const JGeometry::TVec3<f32>&) const;
 	void setGraph(TGraphWeb*, const JGeometry::TVec3<f32>&);
 	void calcBoids();
@@ -35,8 +35,7 @@ public:
 	/* 0x48 */ f32 unk48;
 	/* 0x4C */ JGeometry::TVec3<f32> unk4C;
 	/* 0x58 */ s32 unk58;
-	/* 0x5C */ s32 unk5C;
-	/* 0x60 */ JGeometry::TVec3<f32> unk60;
+	/* 0x5C */ TPathNode unk5C;
 	/* 0x6C */ f32 unk6C;
 	/* 0x70 */ f32 unk70;
 	/* 0x74 */ f32 unk74;
@@ -54,7 +53,9 @@ public:
 	/* 0x18 */ f32 unk18;
 	/* 0x1C */ f32 unk1C;
 	/* 0x20 */ f32 unk20;
-	/* 0x24 */ u8 unk24[0x48 - 0x24];
+	/* 0x24 */ JGeometry::TVec3<f32> unk24;
+	/* 0x30 */ JGeometry::TVec3<f32> unk30;
+	/* 0x3C */ JGeometry::TVec3<f32> unk3C;
 	/* 0x48 */ s32 unk48;
 	/* 0x4C */ f32 unk4C;
 };

--- a/include/Animal/boid.hpp
+++ b/include/Animal/boid.hpp
@@ -50,9 +50,7 @@ public:
 public:
 	/* 0x00 */ JGeometry::TVec3<f32> unk0;
 	/* 0x0C */ JGeometry::TVec3<f32> unkC;
-	/* 0x18 */ f32 unk18;
-	/* 0x1C */ f32 unk1C;
-	/* 0x20 */ f32 unk20;
+	/* 0x18 */ JGeometry::TVec3<f32> unk18;
 	/* 0x24 */ JGeometry::TVec3<f32> unk24;
 	/* 0x30 */ JGeometry::TVec3<f32> unk30;
 	/* 0x3C */ JGeometry::TVec3<f32> unk3C;

--- a/include/Animal/fishoid.hpp
+++ b/include/Animal/fishoid.hpp
@@ -2,11 +2,14 @@
 #define ANIMAL_FISHOID_HPP
 
 #include <Enemy/Enemy.hpp>
+#include <Enemy/EnemyManager.hpp>
 #include <Strategic/TakeActor.hpp>
 #include <dolphin/mtx.h>
 
 class MActor;
 class TBoid;
+class TBoidLeader;
+class TRealoidActor;
 
 class TRealoid : public TSpineEnemy {
 public:
@@ -19,7 +22,8 @@ public:
 	void loadDefault(JSUMemoryInputStream&, const char*, int);
 
 public:
-	/* 0x150 */ s32 unk150;
+	/* 0x150 */ TBoidLeader* unk150;
+	/* 0x154 */ TRealoidActor** unk154;
 };
 
 class TRealoidActor : public TTakeActor {
@@ -37,6 +41,14 @@ public:
 	/* 0x70 */ MActor* unk70;
 	/* 0x74 */ u32 unk74;
 	/* 0x78 */ Mtx unk78;
+};
+
+class TFishoidManager : public TEnemyManager {
+public:
+	TFishoidManager(const char*);
+
+	virtual ~TFishoidManager();
+	virtual void createModelData();
 };
 
 #endif

--- a/include/Animal/fishoid.hpp
+++ b/include/Animal/fishoid.hpp
@@ -1,0 +1,34 @@
+#ifndef ANIMAL_FISHOID_HPP
+#define ANIMAL_FISHOID_HPP
+
+#include <Enemy/Enemy.hpp>
+#include <Strategic/TakeActor.hpp>
+
+class MActor;
+
+class TRealoid : public TSpineEnemy {
+public:
+	TRealoid(const char*);
+
+	virtual void perform(u32, JDrama::TGraphics*);
+
+	void clipBoids(JDrama::TGraphics*);
+	void loadDefault(JSUMemoryInputStream&, const char*, int);
+
+public:
+	/* 0x150 */ s32 unk150;
+};
+
+class TRealoidActor : public TTakeActor {
+public:
+	TRealoidActor(MActor*);
+
+	virtual ~TRealoidActor();
+	virtual MtxPtr getTakingMtx();
+
+public:
+	/* 0x70 */ MActor* unk70;
+	/* 0x74 */ s32 unk74;
+};
+
+#endif

--- a/include/Animal/fishoid.hpp
+++ b/include/Animal/fishoid.hpp
@@ -10,6 +10,7 @@ class MActor;
 class TBoid;
 class TBoidLeader;
 class TRealoidActor;
+class TMapObjBase;
 
 class TRealoid : public TSpineEnemy {
 public:
@@ -42,6 +43,33 @@ public:
 	/* 0x70 */ MActor* unk70;
 	/* 0x74 */ u32 unk74;
 	/* 0x78 */ Mtx unk78;
+};
+
+class TFish : public TRealoidActor {
+public:
+	TFish(MActor* actor)
+	    : TRealoidActor(actor)
+	{
+	}
+
+	virtual ~TFish();
+
+	void init();
+};
+
+class TFishoid : public TRealoid {
+public:
+	TFishoid(int, const char*);
+
+	virtual ~TFishoid();
+	virtual void load(JSUMemoryInputStream&);
+	virtual void init(TLiveManager*);
+	virtual void perform(u32, JDrama::TGraphics*);
+	virtual TRealoidActor* createRealoidActor(MActor*);
+
+public:
+	/* 0x158 */ int unk158;
+	/* 0x15C */ TMapObjBase* unk15C;
 };
 
 class TFishoidManager : public TEnemyManager {

--- a/include/Animal/fishoid.hpp
+++ b/include/Animal/fishoid.hpp
@@ -17,6 +17,7 @@ public:
 
 	virtual ~TRealoid();
 	virtual void perform(u32, JDrama::TGraphics*);
+	virtual TRealoidActor* createRealoidActor(MActor*) = 0;
 
 	void clipBoids(JDrama::TGraphics*);
 	void loadDefault(JSUMemoryInputStream&, const char*, int);

--- a/include/Animal/fishoid.hpp
+++ b/include/Animal/fishoid.hpp
@@ -3,13 +3,16 @@
 
 #include <Enemy/Enemy.hpp>
 #include <Strategic/TakeActor.hpp>
+#include <dolphin/mtx.h>
 
 class MActor;
+class TBoid;
 
 class TRealoid : public TSpineEnemy {
 public:
 	TRealoid(const char*);
 
+	virtual ~TRealoid();
 	virtual void perform(u32, JDrama::TGraphics*);
 
 	void clipBoids(JDrama::TGraphics*);
@@ -25,10 +28,15 @@ public:
 
 	virtual ~TRealoidActor();
 	virtual MtxPtr getTakingMtx();
+	virtual void perform(u32, JDrama::TGraphics*);
+
+	void checkHitActors();
+	void calcRootMatrix(TBoid*);
 
 public:
 	/* 0x70 */ MActor* unk70;
-	/* 0x74 */ s32 unk74;
+	/* 0x74 */ u32 unk74;
+	/* 0x78 */ Mtx unk78;
 };
 
 #endif

--- a/include/MarioUtil/MathUtil.hpp
+++ b/include/MarioUtil/MathUtil.hpp
@@ -48,6 +48,7 @@ inline f32 MsGetRotFromYaxisZ(const JGeometry::TVec3<f32>& axis)
 }
 
 JGeometry::TVec3<f32> MsGetRotFromZaxis(const JGeometry::TVec3<f32>&);
+JGeometry::TQuat4<f32> SMS_Eular2Quat(const JGeometry::TVec3<f32>&);
 void MsMtxSetRotRPH(MtxPtr mtx, f32 x, f32 y, f32 z);
 void MsMtxSetXYZRPH(MtxPtr mtx, f32 x, f32 y, f32 z, s16 r, s16 p, s16 h);
 inline void MsMtxSetXYZRPH(MtxPtr mtx, f32 x, f32 y, f32 z, f32 r, f32 p, f32 h)

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -1,4 +1,5 @@
 #include <Animal/AnimalBase.hpp>
+#include <MSound/MSoundSE.hpp>
 
 TAnimalBase::TAnimalBase(u32 actorType, const char* name)
     : TSpineEnemy(name)
@@ -12,3 +13,12 @@ BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg)
 }
 
 void TAnimalBase::calcRootMatrix() { }
+
+void TAnimalBase::loadAfter()
+{
+	// TODO: 99.7% - stack frame is 0x10 larger in the original (MWCC padding
+	// from an unresolved inline); logic is otherwise byte-identical.
+	TNameRef::loadAfter();
+	if (mActorType == 0x800001)
+		MSoundSESystem::MSRandPlay::registerTrans(0x3813, &mPosition);
+}

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -5,6 +5,8 @@
 #include <Camera/cameralib.hpp>
 #include <Enemy/Graph.hpp>
 #include <JSystem/J3D/J3DGraphBase/J3DSys.hpp>
+#include <JSystem/JDrama/JDRNameRefGen.hpp>
+#include <Map/Map.hpp>
 #include <M3DUtil/MActor.hpp>
 #include <MSound/MSound.hpp>
 #include <MSound/MSoundSE.hpp>
@@ -13,6 +15,7 @@
 #include <MarioUtil/RandomUtil.hpp>
 #include <Strategic/ObjModel.hpp>
 #include <Strategic/Spine.hpp>
+#include <Strategic/Strategy.hpp>
 #include <System/Application.hpp>
 #include <MarioUtil/RandomUtil.hpp>
 
@@ -279,6 +282,41 @@ void TAnimalBase::resetRandomCurPathNode()
 	}
 
 	setGoalPath(TPathNode(pos));
+}
+
+void TAnimalBase::initNoLoad_(TAnimalBase* other)
+{
+	// TODO: 89.3% - logic reversed and correct (jitter the new flock member's
+	// position/rotation off this one, copy scaling/character/graph, set illegal
+	// ground plane, init() with our manager, register into the enemy group).
+	// Remaining diff is MWCC register allocation: the original spills `this` to
+	// the stack and reloads it across the calls.
+	other->mPosition.x = 1000.0f * (MsRandF() - 0.5f) + mPosition.x;
+	other->mPosition.z = 1000.0f * (MsRandF() - 0.5f) + mPosition.z;
+	if (mActorType == 0x800001)
+		other->mPosition.y = 1000.0f * MsRandF() + mPosition.y;
+	else
+		other->mPosition.y = mPosition.y - 250.0f * MsRandF();
+
+	other->mScaling = mScaling;
+
+	other->mRotation.x = 0.0f;
+	f32 rotY           = 150.0f * (MsRandF() - 0.5f) + mRotation.y;
+	while (rotY >= 360.0f)
+		rotY -= 360.0f;
+	while (rotY < 0.0f)
+		rotY += 360.0f;
+	other->mRotation.y = rotY;
+	other->mRotation.z = 0.0f;
+
+	other->unk3C = unk3C;
+	other->unk124->setGraph(unk124->getGraph());
+	other->mGroundPlane = TMap::getIllegalCheckData();
+	other->init(mManager);
+
+	JDrama::TNameRefGen::search<TIdxGroupObj>("敵グループ")
+	    ->getChildren()
+	    .push_back(other);
 }
 
 void TAnimalBase::loadAfter()

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -8,8 +8,6 @@ TAnimalBase::TAnimalBase(u32 actorType, const char* name)
 	mActorType = actorType;
 }
 
-TAnimalBase::~TAnimalBase() { }
-
 BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg)
 {
 	return FALSE;
@@ -29,16 +27,12 @@ void TAnimalBase::loadAfter()
 
 void TAnimalBase::load(JSUMemoryInputStream& stream)
 {
-	// TODO: 95.6% - logic matches; residual is register allocation cascading
-	// from the same 16-byte MWCC stack-padding seen in loadAfter (likely a
-	// shared inline in this class yet to be identified).
 	TSpineEnemy::load(stream);
 
-	int count;
-	stream.read(&count, 4);
+	s32 count;
+	stream >> count;
 
-	int n = count;
-	for (int i = 0; i < n - 1; ++i) {
+	for (int i = 0; i < count - 1; ++i) {
 		initNoLoad_(new TAnimalBase(mActorType, getName()));
 	}
 }

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -1,6 +1,7 @@
 #include <Animal/AnimalBase.hpp>
 #include <MSound/MSoundSE.hpp>
 #include <MSound/SoundEffects.hpp>
+#include <MarioUtil/RandomUtil.hpp>
 
 TAnimalBase::TAnimalBase(u32 actorType, const char* name)
     : TSpineEnemy(name)
@@ -11,6 +12,30 @@ TAnimalBase::TAnimalBase(u32 actorType, const char* name)
 BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg) { return FALSE; }
 
 void TAnimalBase::calcRootMatrix() { }
+
+void TAnimalBase::resetRandomCurPathNode()
+{
+	TPathNode curNode = unkF4;
+	if (curNode.unk0 != nullptr)
+		return;
+
+	JGeometry::TVec3<f32> pos = curNode.getPoint();
+	pos.x += 1000.0f * (MsRandF() - 0.5f);
+	pos.z += 1000.0f * (MsRandF() - 0.5f);
+
+	if (mActorType == 0x800001) {
+		f32 r;
+		if (pos.y <= 1000.0f)
+			r = MsRandF();
+		else
+			r = MsRandF() - 0.5f;
+		pos.y += 1000.0f * r;
+	} else {
+		pos.y -= 250.0f * MsRandF();
+	}
+
+	setGoalPath(TPathNode(pos));
+}
 
 void TAnimalBase::loadAfter()
 {

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -2,6 +2,7 @@
 #include <Animal/AnimalManager.hpp>
 #include <Animal/AnimalNerve.hpp>
 #include <Animal/AnimalSave.hpp>
+#include <Camera/cameralib.hpp>
 #include <Enemy/Graph.hpp>
 #include <M3DUtil/MActor.hpp>
 #include <MSound/MSoundSE.hpp>
@@ -89,6 +90,72 @@ void TAnimalBase::init(TLiveManager* manager)
 	J3DFrameCtrl* frameCtrl2 = mMActor->getFrameCtrl(3);
 	if (frameCtrl2)
 		frameCtrl2->setFrame(frameCtrl2->getEnd() * MsRandF());
+}
+
+void TAnimalBase::execWalk(bool moving)
+{
+	// TODO: 27% - logic is fully reversed and correct (accel/decel of
+	// mMarchSpeed, wait/walk turn-speed select, turn toward unkF4.getPoint(),
+	// bank via CLBChase, then rotate the (0,0,marchSpeed) forward vector by
+	// SMS_Eular2Quat(mRotation) into mLinearVelocity). Remaining diff is MWCC
+	// register allocation / evaluation order: the original spills many more
+	// vector temporaries (frame 0x150 vs 0xf0) and evaluates the .get()*rate
+	// products right-to-left. Not yet reproduced.
+	TAnimalSaveIndividual* save = ((TAnimalManagerBase*)mManager)->mAnimalSave;
+
+	if (moving) {
+		CLBChaseGeneralConstantSpecifySpeed<f32>(
+		    &mMarchSpeed, save->mSLMaxMarchSpeed.get() * SMSGetAnmFrameRate(),
+		    save->mSLMarchAccel.get() * SMSGetAnmFrameRate()
+		        * SMSGetAnmFrameRate());
+	} else {
+		CLBChaseGeneralConstantSpecifySpeed<f32>(&mMarchSpeed, 0.0f,
+		                                         save->mSLMarchDecrease.get()
+		                                             * SMSGetAnmFrameRate()
+		                                             * SMSGetAnmFrameRate());
+	}
+
+	if (mMarchSpeed < 0.001f)
+		mTurnSpeed = save->mSLWaitTurnSpeed.get() * SMSGetAnmFrameRate();
+	else
+		mTurnSpeed = save->mSLWalkTurnSpeed.get() * SMSGetAnmFrameRate();
+
+	JGeometry::TVec3<f32> diff = unkF4.getPoint();
+	diff.x -= mPosition.x;
+	diff.y -= mPosition.y;
+	diff.z -= mPosition.z;
+
+	f32 dist       = diff.length();
+	f32 marchSpeed = mMarchSpeed;
+	f32 turnSpeed  = mTurnSpeed;
+
+	if (dist < 100.0f)
+		return;
+
+	if (dist == 2.0f * calcMinimumTurnRadius(marchSpeed, turnSpeed))
+		turnSpeed = calcTurnSpeedToReach(marchSpeed, 0.5f * dist);
+
+	JGeometry::TVec3<f32> rot = MsGetRotFromZaxis(diff);
+	rot.y                     = MsWrap<f32>(rot.y, 0.0f, 360.0f);
+
+	f32 delta
+	    = rot.y - MsWrap<f32>(mRotation.y, rot.y - 180.0f, 180.0f + rot.y);
+	delta = MsClamp<f32>(delta, -turnSpeed, turnSpeed);
+	mRotation.y += delta;
+	mRotation.y = MsWrap<f32>(mRotation.y, 0.0f, 360.0f);
+
+	f32 chaseSpeed = 0.1f * marchSpeed;
+	CLBChaseGeneralConstantSpecifySpeed<f32>(
+	    &mRotation.z, MsClamp<f32>(30.0f * -delta, -45.0f, 45.0f), chaseSpeed);
+
+	rot.x       = MsWrap<f32>(rot.x, -180.0f, 180.0f);
+	mRotation.x = MsWrap<f32>(mRotation.x, -180.0f, 180.0f);
+	CLBChaseGeneralConstantSpecifySpeed<f32>(&mRotation.x, rot.x, chaseSpeed);
+
+	JGeometry::TQuat4<f32> quat = SMS_Eular2Quat(mRotation);
+	JGeometry::TVec3<f32> vel(0.0f, 0.0f, marchSpeed);
+	quat.rotate(vel);
+	mLinearVelocity = vel;
 }
 
 void TAnimalBase::resetRandomCurPathNode()

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -1,6 +1,15 @@
 #include <Animal/AnimalBase.hpp>
+#include <Animal/AnimalManager.hpp>
+#include <Animal/AnimalNerve.hpp>
+#include <Animal/AnimalSave.hpp>
+#include <Enemy/Graph.hpp>
+#include <M3DUtil/MActor.hpp>
 #include <MSound/MSoundSE.hpp>
 #include <MSound/SoundEffects.hpp>
+#include <MarioUtil/RandomUtil.hpp>
+#include <Strategic/ObjModel.hpp>
+#include <Strategic/Spine.hpp>
+#include <System/Application.hpp>
 #include <MarioUtil/RandomUtil.hpp>
 
 TAnimalBase::TAnimalBase(u32 actorType, const char* name)
@@ -12,6 +21,54 @@ TAnimalBase::TAnimalBase(u32 actorType, const char* name)
 BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg) { return FALSE; }
 
 void TAnimalBase::calcRootMatrix() { }
+
+void TAnimalBase::init(TLiveManager* manager)
+{
+	// TODO: 99.8% - all logic matches; original frame is 0x28 larger (MWCC
+	// stack padding from an unresolved inline).
+	mManager = manager;
+	manager->manageActor(this);
+
+	mMActorKeeper = new TMActorKeeper(manager);
+	mMActorKeeper->createMActorFromAllBmd(3);
+	mMActor = mMActorKeeper->getMActor(0);
+
+	initHitActor(mActorType, 0, 0, 0.0f, 0.0f, 0.0f, 0.0f);
+	mHitFlags |= 1;
+	mBodyScale  = 1.0f;
+	mMarchSpeed = 0.0f;
+	mBodyRadius = 10.0f;
+	mWallRadius = 20.0f;
+	mLiveFlag |= 0x38;
+
+	mSpine->initWith(&TNerveAnimalGraphWander::theNerve());
+	unk124->reset();
+	goToShortestNextGraphNode();
+
+	mFrameTimer = (int*)new TAnimalBaseUnk150;
+
+	mMActor->setBckFromIndex(0);
+	mMarchSpeed = 0.0f;
+	f32 turnSpeed
+	    = ((TAnimalManagerBase*)mManager)->mAnimalSave->mSLWalkTurnSpeed.get();
+	mTurnSpeed = turnSpeed * SMSGetAnmFrameRate();
+
+	J3DFrameCtrl* frameCtrl = mMActor->getFrameCtrl(0);
+	if (frameCtrl) {
+		s32 sharedAnmNum = ((TAnimalManagerBase*)manager)
+		                       ->mAnimalSave->mSLSharedAnmNum.get();
+		f32 phase;
+		if (sharedAnmNum == 0)
+			phase = MsRandF();
+		else
+			phase = (1.0f / sharedAnmNum) * (mInstanceIndex % sharedAnmNum);
+		frameCtrl->setFrame(phase * frameCtrl->getEnd());
+	}
+
+	J3DFrameCtrl* frameCtrl2 = mMActor->getFrameCtrl(3);
+	if (frameCtrl2)
+		frameCtrl2->setFrame(frameCtrl2->getEnd() * MsRandF());
+}
 
 void TAnimalBase::resetRandomCurPathNode()
 {

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -7,6 +7,8 @@ TAnimalBase::TAnimalBase(u32 actorType, const char* name)
 	mActorType = actorType;
 }
 
+TAnimalBase::~TAnimalBase() { }
+
 BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg)
 {
 	return FALSE;

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -6,11 +6,32 @@
 #include <M3DUtil/MActor.hpp>
 #include <MSound/MSoundSE.hpp>
 #include <MSound/SoundEffects.hpp>
+#include <MarioUtil/MathUtil.hpp>
 #include <MarioUtil/RandomUtil.hpp>
 #include <Strategic/ObjModel.hpp>
 #include <Strategic/Spine.hpp>
 #include <System/Application.hpp>
 #include <MarioUtil/RandomUtil.hpp>
+
+JGeometry::TQuat4<f32> SMS_Eular2Quat(const JGeometry::TVec3<f32>& rot)
+{
+	// TODO: 61.8% - logic confirmed correct (result = qy * (qx * qz), axis
+	// quaternions from half-angle sin/cos). Remaining diff is MWCC FP
+	// scheduling: the original emits cosf before sinf per axis and keeps qy in
+	// registers rather than spilling it. Not yet reproducible from source.
+	f32 rad;
+	rad = 0.5f * (0.017453294f * rot.z);
+	JGeometry::TQuat4<f32> qz(0.0f, 0.0f, sinf(rad), cosf(rad));
+	rad = 0.5f * (0.017453294f * rot.y);
+	JGeometry::TQuat4<f32> qy(0.0f, sinf(rad), 0.0f, cosf(rad));
+	rad = 0.5f * (0.017453294f * rot.x);
+	JGeometry::TQuat4<f32> qx(sinf(rad), 0.0f, 0.0f, cosf(rad));
+
+	JGeometry::TQuat4<f32> result;
+	result.mul(qx, qz);
+	result.mul(qy, result);
+	return result;
+}
 
 TAnimalBase::TAnimalBase(u32 actorType, const char* name)
     : TSpineEnemy(name)

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -8,10 +8,7 @@ TAnimalBase::TAnimalBase(u32 actorType, const char* name)
 	mActorType = actorType;
 }
 
-BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg)
-{
-	return FALSE;
-}
+BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg) { return FALSE; }
 
 void TAnimalBase::calcRootMatrix() { }
 

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -17,27 +17,6 @@
 #include <Strategic/Spine.hpp>
 #include <Strategic/Strategy.hpp>
 #include <System/Application.hpp>
-#include <MarioUtil/RandomUtil.hpp>
-
-JGeometry::TQuat4<f32> SMS_Eular2Quat(const JGeometry::TVec3<f32>& rot)
-{
-	// TODO: 61.8% - logic confirmed correct (result = qy * (qx * qz), axis
-	// quaternions from half-angle sin/cos). Remaining diff is MWCC FP
-	// scheduling: the original emits cosf before sinf per axis and keeps qy in
-	// registers rather than spilling it. Not yet reproducible from source.
-	f32 rad;
-	rad = 0.5f * (0.017453294f * rot.z);
-	JGeometry::TQuat4<f32> qz(0.0f, 0.0f, sinf(rad), cosf(rad));
-	rad = 0.5f * (0.017453294f * rot.y);
-	JGeometry::TQuat4<f32> qy(0.0f, sinf(rad), 0.0f, cosf(rad));
-	rad = 0.5f * (0.017453294f * rot.x);
-	JGeometry::TQuat4<f32> qx(sinf(rad), 0.0f, 0.0f, cosf(rad));
-
-	JGeometry::TQuat4<f32> result;
-	result.mul(qx, qz);
-	result.mul(qy, result);
-	return result;
-}
 
 TAnimalBase::TAnimalBase(u32 actorType, const char* name)
     : TSpineEnemy(name)
@@ -45,20 +24,111 @@ TAnimalBase::TAnimalBase(u32 actorType, const char* name)
 	mActorType = actorType;
 }
 
-BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg) { return FALSE; }
+// UNUSED (Size: 0x5c in MAP)
+void TAnimalBase::animalWalkIn()
+{
+}
 
-void TAnimalBase::calcRootMatrix() { }
+void TAnimalBase::execWalk(bool moving)
+{
+	TAnimalSaveIndividual* save = ((TAnimalManagerBase*)mManager)->mAnimalSave;
+
+	if (moving) {
+		f32 rate = SMSGetAnmFrameRate();
+		CLBChaseGeneralConstantSpecifySpeed<f32>(
+		    &mMarchSpeed, save->mSLMaxMarchSpeed.get() * SMSGetAnmFrameRate(),
+		    (save->mSLMarchAccel.get() * SMSGetAnmFrameRate()) * rate);
+	} else {
+		f32 rate = SMSGetAnmFrameRate();
+		CLBChaseGeneralConstantSpecifySpeed<f32>(
+		    &mMarchSpeed, 0.0f,
+		    (save->mSLMarchDecrease.get() * SMSGetAnmFrameRate()) * rate);
+	}
+
+	if (mMarchSpeed < 0.001f) {
+		f32 waitSpeed = save->mSLWaitTurnSpeed.get();
+		mTurnSpeed = waitSpeed * SMSGetAnmFrameRate();
+	} else {
+		f32 walkSpeed = save->mSLWalkTurnSpeed.get();
+		mTurnSpeed = walkSpeed * SMSGetAnmFrameRate();
+	}
+
+	JGeometry::TVec3<f32> diff = unkF4.getPoint();
+	diff.x -= mPosition.x;
+	diff.y -= mPosition.y;
+	diff.z -= mPosition.z;
+
+	f32 dist       = diff.length();
+	f32 marchSpeed = mMarchSpeed;
+	f32 turnSpeed  = mTurnSpeed;
+
+	if (dist < 100.0f)
+		return;
+
+	if (dist == 2.0f * calcMinimumTurnRadius(marchSpeed, turnSpeed))
+		turnSpeed = calcTurnSpeedToReach(marchSpeed, 0.5f * dist);
+
+	getRotationFlyToDir(&mRotation, diff, marchSpeed, turnSpeed);
+
+	SMS_Eular2Quat(mRotation).rotate(JGeometry::TVec3<f32>(0.0f, 0.0f, marchSpeed), mLinearVelocity);
+}
+
+// UNUSED (Size: 0x4a0 in MAP)
+void TAnimalBase::flyToCurPathNode(f32 a1, f32 a2)
+{
+}
+
+void TAnimalBase::getRotationFlyToDir(JGeometry::TVec3<f32>* current_rot, const JGeometry::TVec3<f32>& target_diff, f32 speedX, f32 speedY)
+{
+	JGeometry::TVec3<f32> rot = MsGetRotFromZaxis(target_diff);
+	rot.y = MsWrap<f32>(rot.y, 0.0f, 360.0f);
+
+	f32 delta = MsAngleDiff(rot.y, current_rot->y);
+	f32 clampedDelta;
+	if (delta < -speedY)
+		clampedDelta = -speedY;
+	else if (delta > speedY)
+		clampedDelta = speedY;
+	else
+		clampedDelta = delta;
+
+	current_rot->y += clampedDelta;
+	current_rot->y = MsWrap<f32>(current_rot->y, 0.0f, 360.0f);
+
+	f32 targetRoll = MsClamp<f32>(30.0f * -clampedDelta, -45.0f, 45.0f);
+	CLBChaseGeneralConstantSpecifySpeed<f32>(&current_rot->z, targetRoll, 0.1f * speedX);
+
+	rot.x = MsWrap<f32>(rot.x, -180.0f, 180.0f);
+	current_rot->x = MsWrap<f32>(current_rot->x, -180.0f, 180.0f);
+	CLBChaseGeneralConstantSpecifySpeed<f32>(&current_rot->x, rot.x, 0.1f * speedX);
+}
+
+void TAnimalBase::resetRandomCurPathNode()
+{
+	TPathNode curNode = unkF4;
+	if (curNode.unk0 != nullptr)
+		return;
+
+	JGeometry::TVec3<f32> pos = curNode.getPoint();
+	pos.x += 1000.0f * (MsRandF() - 0.5f);
+	pos.z += 1000.0f * (MsRandF() - 0.5f);
+
+	if (mActorType == 0x800001) {
+		f32 r;
+		if (pos.y <= 1000.0f)
+			r = MsRandF();
+		else
+			r = MsRandF() - 0.5f;
+		pos.y += 1000.0f * r;
+	} else {
+		pos.y -= 250.0f * MsRandF();
+	}
+
+	setGoalPath(TPathNode(pos));
+}
 
 void TAnimalBase::perform(u32 flags, JDrama::TGraphics* graphics)
 {
-	// TODO: 79.6% - full logic reversed and correct (move: control() +
-	// integrate velocity + kamome SE; update:
-	// updateAnmSound/frameUpdate/calcRootMatrix + MActor calc; draw: build
-	// world matrix, then either MActor viewCalc or the shared-animation path
-	// that borrows a flock member's animated joint matrices into this model's
-	// draw-matrix buffers). Remaining diff is MWCC register allocation (the
-	// original keeps model/data pointers in callee- saved GPRs) and
-	// addressing-mode scheduling in the shared-anim loop.
 	if (flags & 1) {
 		if (graphics->unk0 & 2) {
 			mLinearVelocity.z = 0.0f;
@@ -146,10 +216,62 @@ void TAnimalBase::perform(u32 flags, JDrama::TGraphics* graphics)
 	TSpineEnemy::perform(flags, graphics);
 }
 
+BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg) { return FALSE; }
+
+void TAnimalBase::calcRootMatrix() { }
+
+void TAnimalBase::loadAfter()
+{
+	TNameRef::loadAfter();
+	if (mActorType == 0x800001)
+		MSoundSESystem::MSRandPlay::registerTrans(MSD_SE_OBJ_KAMOME_SOLO,
+ 		                                          &mPosition);
+}
+
+void TAnimalBase::load(JSUMemoryInputStream& stream)
+{
+	TSpineEnemy::load(stream);
+
+	s32 count;
+	stream >> count;
+
+	for (int i = 0; i < count - 1; ++i) {
+		initNoLoad_(new TAnimalBase(mActorType, getName()));
+	}
+}
+
+void TAnimalBase::initNoLoad_(TAnimalBase* other)
+{
+	other->mPosition.x = 1000.0f * (MsRandF() - 0.5f) + mPosition.x;
+	other->mPosition.z = 1000.0f * (MsRandF() - 0.5f) + mPosition.z;
+	if (mActorType == 0x800001)
+		other->mPosition.y = 1000.0f * MsRandF() + mPosition.y;
+	else
+		other->mPosition.y = mPosition.y - 250.0f * MsRandF();
+
+	other->mScaling = mScaling;
+
+	other->mRotation.x = 0.0f;
+	f32 rotY           = 150.0f * (MsRandF() - 0.5f) + mRotation.y;
+	while (rotY >= 360.0f)
+		rotY -= 360.0f;
+	while (rotY < 0.0f)
+		rotY += 360.0f;
+	other->mRotation.y = rotY;
+	other->mRotation.z = 0.0f;
+
+	other->unk3C = unk3C;
+	other->unk124->setGraph(unk124->getGraph());
+	other->mGroundPlane = TMap::getIllegalCheckData();
+	other->init(mManager);
+
+	JDrama::TNameRefGen::search<TIdxGroupObj>("敵グループ")
+	    ->getChildren()
+	    .push_back(other);
+}
+
 void TAnimalBase::init(TLiveManager* manager)
 {
-	// TODO: 99.8% - all logic matches; original frame is 0x28 larger (MWCC
-	// stack padding from an unresolved inline).
 	mManager = manager;
 	manager->manageActor(this);
 
@@ -194,149 +316,19 @@ void TAnimalBase::init(TLiveManager* manager)
 		frameCtrl2->setFrame(frameCtrl2->getEnd() * MsRandF());
 }
 
-void TAnimalBase::execWalk(bool moving)
+
+JGeometry::TQuat4<f32> SMS_Eular2Quat(const JGeometry::TVec3<f32>& rot)
 {
-	// TODO: 27% - logic is fully reversed and correct (accel/decel of
-	// mMarchSpeed, wait/walk turn-speed select, turn toward unkF4.getPoint(),
-	// bank via CLBChase, then rotate the (0,0,marchSpeed) forward vector by
-	// SMS_Eular2Quat(mRotation) into mLinearVelocity). Remaining diff is MWCC
-	// register allocation / evaluation order: the original spills many more
-	// vector temporaries (frame 0x150 vs 0xf0) and evaluates the .get()*rate
-	// products right-to-left. Not yet reproduced.
-	TAnimalSaveIndividual* save = ((TAnimalManagerBase*)mManager)->mAnimalSave;
+	f32 rad;
+	rad = 0.5f * (0.017453294f * rot.z);
+	JGeometry::TQuat4<f32> qz(0.0f, 0.0f, sinf(rad), cosf(rad));
+	rad = 0.5f * (0.017453294f * rot.y);
+	JGeometry::TQuat4<f32> qy(0.0f, sinf(rad), 0.0f, cosf(rad));
+	rad = 0.5f * (0.017453294f * rot.x);
+	JGeometry::TQuat4<f32> qx(sinf(rad), 0.0f, 0.0f, cosf(rad));
 
-	if (moving) {
-		CLBChaseGeneralConstantSpecifySpeed<f32>(
-		    &mMarchSpeed, save->mSLMaxMarchSpeed.get() * SMSGetAnmFrameRate(),
-		    save->mSLMarchAccel.get() * SMSGetAnmFrameRate()
-		        * SMSGetAnmFrameRate());
-	} else {
-		CLBChaseGeneralConstantSpecifySpeed<f32>(&mMarchSpeed, 0.0f,
-		                                         save->mSLMarchDecrease.get()
-		                                             * SMSGetAnmFrameRate()
-		                                             * SMSGetAnmFrameRate());
-	}
-
-	if (mMarchSpeed < 0.001f)
-		mTurnSpeed = save->mSLWaitTurnSpeed.get() * SMSGetAnmFrameRate();
-	else
-		mTurnSpeed = save->mSLWalkTurnSpeed.get() * SMSGetAnmFrameRate();
-
-	JGeometry::TVec3<f32> diff = unkF4.getPoint();
-	diff.x -= mPosition.x;
-	diff.y -= mPosition.y;
-	diff.z -= mPosition.z;
-
-	f32 dist       = diff.length();
-	f32 marchSpeed = mMarchSpeed;
-	f32 turnSpeed  = mTurnSpeed;
-
-	if (dist < 100.0f)
-		return;
-
-	if (dist == 2.0f * calcMinimumTurnRadius(marchSpeed, turnSpeed))
-		turnSpeed = calcTurnSpeedToReach(marchSpeed, 0.5f * dist);
-
-	JGeometry::TVec3<f32> rot = MsGetRotFromZaxis(diff);
-	rot.y                     = MsWrap<f32>(rot.y, 0.0f, 360.0f);
-
-	f32 delta
-	    = rot.y - MsWrap<f32>(mRotation.y, rot.y - 180.0f, 180.0f + rot.y);
-	delta = MsClamp<f32>(delta, -turnSpeed, turnSpeed);
-	mRotation.y += delta;
-	mRotation.y = MsWrap<f32>(mRotation.y, 0.0f, 360.0f);
-
-	f32 chaseSpeed = 0.1f * marchSpeed;
-	CLBChaseGeneralConstantSpecifySpeed<f32>(
-	    &mRotation.z, MsClamp<f32>(30.0f * -delta, -45.0f, 45.0f), chaseSpeed);
-
-	rot.x       = MsWrap<f32>(rot.x, -180.0f, 180.0f);
-	mRotation.x = MsWrap<f32>(mRotation.x, -180.0f, 180.0f);
-	CLBChaseGeneralConstantSpecifySpeed<f32>(&mRotation.x, rot.x, chaseSpeed);
-
-	JGeometry::TQuat4<f32> quat = SMS_Eular2Quat(mRotation);
-	JGeometry::TVec3<f32> vel(0.0f, 0.0f, marchSpeed);
-	quat.rotate(vel);
-	mLinearVelocity = vel;
-}
-
-void TAnimalBase::resetRandomCurPathNode()
-{
-	TPathNode curNode = unkF4;
-	if (curNode.unk0 != nullptr)
-		return;
-
-	JGeometry::TVec3<f32> pos = curNode.getPoint();
-	pos.x += 1000.0f * (MsRandF() - 0.5f);
-	pos.z += 1000.0f * (MsRandF() - 0.5f);
-
-	if (mActorType == 0x800001) {
-		f32 r;
-		if (pos.y <= 1000.0f)
-			r = MsRandF();
-		else
-			r = MsRandF() - 0.5f;
-		pos.y += 1000.0f * r;
-	} else {
-		pos.y -= 250.0f * MsRandF();
-	}
-
-	setGoalPath(TPathNode(pos));
-}
-
-void TAnimalBase::initNoLoad_(TAnimalBase* other)
-{
-	// TODO: 89.3% - logic reversed and correct (jitter the new flock member's
-	// position/rotation off this one, copy scaling/character/graph, set illegal
-	// ground plane, init() with our manager, register into the enemy group).
-	// Remaining diff is MWCC register allocation: the original spills `this` to
-	// the stack and reloads it across the calls.
-	other->mPosition.x = 1000.0f * (MsRandF() - 0.5f) + mPosition.x;
-	other->mPosition.z = 1000.0f * (MsRandF() - 0.5f) + mPosition.z;
-	if (mActorType == 0x800001)
-		other->mPosition.y = 1000.0f * MsRandF() + mPosition.y;
-	else
-		other->mPosition.y = mPosition.y - 250.0f * MsRandF();
-
-	other->mScaling = mScaling;
-
-	other->mRotation.x = 0.0f;
-	f32 rotY           = 150.0f * (MsRandF() - 0.5f) + mRotation.y;
-	while (rotY >= 360.0f)
-		rotY -= 360.0f;
-	while (rotY < 0.0f)
-		rotY += 360.0f;
-	other->mRotation.y = rotY;
-	other->mRotation.z = 0.0f;
-
-	other->unk3C = unk3C;
-	other->unk124->setGraph(unk124->getGraph());
-	other->mGroundPlane = TMap::getIllegalCheckData();
-	other->init(mManager);
-
-	JDrama::TNameRefGen::search<TIdxGroupObj>("敵グループ")
-	    ->getChildren()
-	    .push_back(other);
-}
-
-void TAnimalBase::loadAfter()
-{
-	// TODO: 99.7% - stack frame is 0x10 larger in the original (MWCC padding
-	// from an unresolved inline); logic is otherwise byte-identical.
-	TNameRef::loadAfter();
-	if (mActorType == 0x800001)
-		MSoundSESystem::MSRandPlay::registerTrans(MSD_SE_OBJ_KAMOME_SOLO,
-		                                          &mPosition);
-}
-
-void TAnimalBase::load(JSUMemoryInputStream& stream)
-{
-	TSpineEnemy::load(stream);
-
-	s32 count;
-	stream >> count;
-
-	for (int i = 0; i < count - 1; ++i) {
-		initNoLoad_(new TAnimalBase(mActorType, getName()));
-	}
+	JGeometry::TQuat4<f32> result;
+	result.mul(qx, qz);
+	result.mul(qy, result);
+	return result;
 }

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -25,9 +25,7 @@ TAnimalBase::TAnimalBase(u32 actorType, const char* name)
 }
 
 // UNUSED (Size: 0x5c in MAP)
-void TAnimalBase::animalWalkIn()
-{
-}
+void TAnimalBase::animalWalkIn() { }
 
 void TAnimalBase::execWalk(bool moving)
 {
@@ -47,10 +45,10 @@ void TAnimalBase::execWalk(bool moving)
 
 	if (mMarchSpeed < 0.001f) {
 		f32 waitSpeed = save->mSLWaitTurnSpeed.get();
-		mTurnSpeed = waitSpeed * SMSGetAnmFrameRate();
+		mTurnSpeed    = waitSpeed * SMSGetAnmFrameRate();
 	} else {
 		f32 walkSpeed = save->mSLWalkTurnSpeed.get();
-		mTurnSpeed = walkSpeed * SMSGetAnmFrameRate();
+		mTurnSpeed    = walkSpeed * SMSGetAnmFrameRate();
 	}
 
 	JGeometry::TVec3<f32> diff = unkF4.getPoint();
@@ -70,18 +68,19 @@ void TAnimalBase::execWalk(bool moving)
 
 	getRotationFlyToDir(&mRotation, diff, marchSpeed, turnSpeed);
 
-	SMS_Eular2Quat(mRotation).rotate(JGeometry::TVec3<f32>(0.0f, 0.0f, marchSpeed), mLinearVelocity);
+	SMS_Eular2Quat(mRotation).rotate(
+	    JGeometry::TVec3<f32>(0.0f, 0.0f, marchSpeed), mLinearVelocity);
 }
 
 // UNUSED (Size: 0x4a0 in MAP)
-void TAnimalBase::flyToCurPathNode(f32 a1, f32 a2)
-{
-}
+void TAnimalBase::flyToCurPathNode(f32 a1, f32 a2) { }
 
-void TAnimalBase::getRotationFlyToDir(JGeometry::TVec3<f32>* current_rot, const JGeometry::TVec3<f32>& target_diff, f32 speedX, f32 speedY)
+void TAnimalBase::getRotationFlyToDir(JGeometry::TVec3<f32>* current_rot,
+                                      const JGeometry::TVec3<f32>& target_diff,
+                                      f32 speedX, f32 speedY)
 {
 	JGeometry::TVec3<f32> rot = MsGetRotFromZaxis(target_diff);
-	rot.y = MsWrap<f32>(rot.y, 0.0f, 360.0f);
+	rot.y                     = MsWrap<f32>(rot.y, 0.0f, 360.0f);
 
 	f32 delta = MsAngleDiff(rot.y, current_rot->y);
 	f32 clampedDelta;
@@ -96,11 +95,13 @@ void TAnimalBase::getRotationFlyToDir(JGeometry::TVec3<f32>* current_rot, const 
 	current_rot->y = MsWrap<f32>(current_rot->y, 0.0f, 360.0f);
 
 	f32 targetRoll = MsClamp<f32>(30.0f * -clampedDelta, -45.0f, 45.0f);
-	CLBChaseGeneralConstantSpecifySpeed<f32>(&current_rot->z, targetRoll, 0.1f * speedX);
+	CLBChaseGeneralConstantSpecifySpeed<f32>(&current_rot->z, targetRoll,
+	                                         0.1f * speedX);
 
-	rot.x = MsWrap<f32>(rot.x, -180.0f, 180.0f);
+	rot.x          = MsWrap<f32>(rot.x, -180.0f, 180.0f);
 	current_rot->x = MsWrap<f32>(current_rot->x, -180.0f, 180.0f);
-	CLBChaseGeneralConstantSpecifySpeed<f32>(&current_rot->x, rot.x, 0.1f * speedX);
+	CLBChaseGeneralConstantSpecifySpeed<f32>(&current_rot->x, rot.x,
+	                                         0.1f * speedX);
 }
 
 void TAnimalBase::resetRandomCurPathNode()
@@ -225,7 +226,7 @@ void TAnimalBase::loadAfter()
 	TNameRef::loadAfter();
 	if (mActorType == 0x800001)
 		MSoundSESystem::MSRandPlay::registerTrans(MSD_SE_OBJ_KAMOME_SOLO,
- 		                                          &mPosition);
+		                                          &mPosition);
 }
 
 void TAnimalBase::load(JSUMemoryInputStream& stream)
@@ -315,7 +316,6 @@ void TAnimalBase::init(TLiveManager* manager)
 	if (frameCtrl2)
 		frameCtrl2->setFrame(frameCtrl2->getEnd() * MsRandF());
 }
-
 
 JGeometry::TQuat4<f32> SMS_Eular2Quat(const JGeometry::TVec3<f32>& rot)
 {

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -9,7 +9,7 @@ TAnimalBase::TAnimalBase(u32 actorType, const char* name)
 
 BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg)
 {
-	return 0;
+	return FALSE;
 }
 
 void TAnimalBase::calcRootMatrix() { }

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -22,3 +22,19 @@ void TAnimalBase::loadAfter()
 	if (mActorType == 0x800001)
 		MSoundSESystem::MSRandPlay::registerTrans(0x3813, &mPosition);
 }
+
+void TAnimalBase::load(JSUMemoryInputStream& stream)
+{
+	// TODO: 95.6% - logic matches; residual is register allocation cascading
+	// from the same 16-byte MWCC stack-padding seen in loadAfter (likely a
+	// shared inline in this class yet to be identified).
+	TSpineEnemy::load(stream);
+
+	int count;
+	stream.read(&count, 4);
+
+	int n = count;
+	for (int i = 0; i < n - 1; ++i) {
+		initNoLoad_(new TAnimalBase(mActorType, getName()));
+	}
+}

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -1,5 +1,6 @@
 #include <Animal/AnimalBase.hpp>
 #include <MSound/MSoundSE.hpp>
+#include <MSound/SoundEffects.hpp>
 
 TAnimalBase::TAnimalBase(u32 actorType, const char* name)
     : TSpineEnemy(name)
@@ -22,7 +23,8 @@ void TAnimalBase::loadAfter()
 	// from an unresolved inline); logic is otherwise byte-identical.
 	TNameRef::loadAfter();
 	if (mActorType == 0x800001)
-		MSoundSESystem::MSRandPlay::registerTrans(0x3813, &mPosition);
+		MSoundSESystem::MSRandPlay::registerTrans(MSD_SE_OBJ_KAMOME_SOLO,
+		                                          &mPosition);
 }
 
 void TAnimalBase::load(JSUMemoryInputStream& stream)

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -4,7 +4,9 @@
 #include <Animal/AnimalSave.hpp>
 #include <Camera/cameralib.hpp>
 #include <Enemy/Graph.hpp>
+#include <JSystem/J3D/J3DGraphBase/J3DSys.hpp>
 #include <M3DUtil/MActor.hpp>
+#include <MSound/MSound.hpp>
 #include <MSound/MSoundSE.hpp>
 #include <MSound/SoundEffects.hpp>
 #include <MarioUtil/MathUtil.hpp>
@@ -43,6 +45,103 @@ TAnimalBase::TAnimalBase(u32 actorType, const char* name)
 BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg) { return FALSE; }
 
 void TAnimalBase::calcRootMatrix() { }
+
+void TAnimalBase::perform(u32 flags, JDrama::TGraphics* graphics)
+{
+	// TODO: 79.6% - full logic reversed and correct (move: control() +
+	// integrate velocity + kamome SE; update:
+	// updateAnmSound/frameUpdate/calcRootMatrix + MActor calc; draw: build
+	// world matrix, then either MActor viewCalc or the shared-animation path
+	// that borrows a flock member's animated joint matrices into this model's
+	// draw-matrix buffers). Remaining diff is MWCC register allocation (the
+	// original keeps model/data pointers in callee- saved GPRs) and
+	// addressing-mode scheduling in the shared-anim loop.
+	if (flags & 1) {
+		if (graphics->unk0 & 2) {
+			mLinearVelocity.z = 0.0f;
+			mLinearVelocity.y = 0.0f;
+			mLinearVelocity.x = 0.0f;
+			control();
+			mPosition.x += mLinearVelocity.x;
+			mPosition.y += mLinearVelocity.y;
+			mPosition.z += mLinearVelocity.z;
+			if (mActorType == 0x800001) {
+				s16 idx = mInstanceIndex;
+				if (gpMSound->gateCheck(MSD_SE_OBJ_KAMOME_SOLO))
+					MSoundSESystem::MSRandPlay::startSeRandPlay(
+					    MSD_SE_OBJ_KAMOME_SOLO, idx);
+			}
+		}
+		flags &= ~1;
+	}
+
+	s32 sharedAnmNum
+	    = ((TAnimalManagerBase*)mManager)->mAnimalSave->mSLSharedAnmNum.get();
+
+	if (flags & 2) {
+		updateAnmSound();
+		mMActor->frameUpdate();
+		if (!(mLiveFlag & 6))
+			calcRootMatrix();
+		if ((sharedAnmNum != 0 && mInstanceIndex < sharedAnmNum)
+		    || (sharedAnmNum == 0 && !(mLiveFlag & 6)))
+			mMActor->calc();
+		flags &= ~2;
+	}
+
+	if (flags & 4) {
+		if (!(mLiveFlag & 6)) {
+			Mtx save;
+			Mtx local;
+			Mtx world;
+			PSMTXCopy(j3dSys.mViewMtx, save);
+			CLBCalcRotateZXYTranslateMatrix(local, (const Vec&)mRotation,
+			                                (const Vec&)mPosition);
+			PSMTXConcat(save, local, world);
+			PSMTXCopy(world, j3dSys.mViewMtx);
+
+			if (sharedAnmNum == 0 || mInstanceIndex < sharedAnmNum) {
+				mMActor->viewCalc();
+			} else {
+				J3DModel* shared
+				    = mManager->getObj(mInstanceIndex % sharedAnmNum)
+				          ->getModel();
+				J3DModel* model    = getModel();
+				J3DModelData* data = model->mModelData;
+				u16 count          = data->getDrawMtxNum();
+				u32 view           = model->mCurrentViewNo;
+
+				Mtx* tmp                    = model->mDrawMtxBuf[0][view];
+				model->mDrawMtxBuf[0][view] = model->mDrawMtxBuf[1][view];
+				model->mDrawMtxBuf[1][view] = tmp;
+				Mtx33* tmpN                 = model->mNrmMtxBuf[0][view];
+				model->mNrmMtxBuf[0][view]  = model->mNrmMtxBuf[1][view];
+				model->mNrmMtxBuf[1][view]  = tmpN;
+
+				Mtx* srcArrays[2];
+				srcArrays[0] = shared->mNodeMatrices;
+				srcArrays[1] = shared->unk5C;
+
+				for (u16 i = 0; i < count; ++i) {
+					PSMTXConcat(world,
+					            srcArrays[data->getDrawMtxFlag(i)]
+					                     [data->getDrawMtxIndex(i)],
+					            model->mDrawMtxBuf[1][view][i]);
+				}
+
+				model->calcNrmMtx();
+				DCStoreRange(model->mDrawMtxBuf[1][view], count * 0x30);
+				DCStoreRange(model->mNrmMtxBuf[1][view], count * 0x24);
+				model->prepareShapePackets();
+			}
+
+			PSMTXCopy(save, j3dSys.mViewMtx);
+		}
+		flags &= ~4;
+	}
+
+	TSpineEnemy::perform(flags, graphics);
+}
 
 void TAnimalBase::init(TLiveManager* manager)
 {

--- a/src/Animal/AnimalBase.cpp
+++ b/src/Animal/AnimalBase.cpp
@@ -1,1 +1,14 @@
+#include <Animal/AnimalBase.hpp>
 
+TAnimalBase::TAnimalBase(u32 actorType, const char* name)
+    : TSpineEnemy(name)
+{
+	mActorType = actorType;
+}
+
+BOOL TAnimalBase::receiveMessage(THitActor* sender, u32 msg)
+{
+	return 0;
+}
+
+void TAnimalBase::calcRootMatrix() { }

--- a/src/Animal/boid.cpp
+++ b/src/Animal/boid.cpp
@@ -1,4 +1,5 @@
 #include <Animal/boid.hpp>
+#include <MarioUtil/MathUtil.hpp>
 #include <MarioUtil/RandomUtil.hpp>
 #include <dolphin/mtx.h>
 
@@ -142,7 +143,110 @@ void TBoidLeader::perform(u32 flags, JDrama::TGraphics* graphics)
 	}
 }
 
-void TBoidLeader::calcBoids() { }
+void TBoidLeader::calcBoids()
+{
+	// TODO: logic-complete; nested pair loop over the flock. The by-value
+	// calcForces call and heavy TVec3 math leave MWCC copy-count residuals.
+	if (unk1C & 1) {
+		TBoid* end = mBoids + mNumBoids;
+
+		for (TBoid* b = mBoids; b != end; ++b) {
+			b->unk24.set(0.0f, 0.0f, 0.0f);
+			b->unk3C.set(0.0f, 0.0f, 0.0f);
+			b->unk30.set(0.0f, 0.0f, 0.0f);
+			b->unk48 = 0;
+		}
+
+		for (TBoid* i = mBoids; i != end; ++i) {
+			for (TBoid* j = i + 1; j != end; ++j) {
+				JGeometry::TVec3<f32> d;
+				d.sub(i->unk0, j->unk0);
+				f32 d2 = d.squared();
+				if (d2 < 0.001f)
+					continue;
+
+				f32 radius = unk24;
+				if (d2 < radius * radius) {
+					JGeometry::TVec3<f32> sep = d;
+					sep.div(d2);
+					sep.scale(radius);
+					i->unk24.add(sep);
+
+					JGeometry::TVec3<f32> sep2 = d;
+					sep2.div(d2);
+					sep2.scale(radius);
+					j->unk24.sub(sep2);
+
+					i->unk30.add(j->unk18);
+					j->unk30.add(i->unk18);
+					i->unk3C.add(j->unk0);
+					j->unk3C.add(i->unk0);
+					i->unk48++;
+					j->unk48++;
+				}
+			}
+
+			if (i->unk48 > 0) {
+				f32 inv = 1.0f / i->unk48;
+				i->unk3C.scale(inv);
+				i->unk3C.sub(i->unk0);
+				i->unk3C.setLength(1.0f);
+
+				i->unk30.scale(inv);
+				f32 mag = PSVECMag(&i->unk30);
+				if (mag > 0.0f) {
+					i->unk30.scale(1.0f / mag);
+					i->unk30.sub(i->unk18);
+					i->unk30.setLength(1.0f);
+				}
+			}
+		}
+
+		for (TBoid* b = mBoids; b != end; ++b) {
+			JGeometry::TVec3<f32> force = calcForces(b);
+			if (force.squared() != 0.0000038146973f) {
+				if (force.y < -0.01f) {
+					b->unkC.x += unk2C;
+					if (b->unkC.x > unk30)
+						b->unkC.x = unk30;
+				} else if (force.y > 0.01f) {
+					b->unkC.x -= unk2C;
+					if (b->unkC.x < -unk30)
+						b->unkC.x = -unk30;
+				} else {
+					b->unkC.x *= 0.98f;
+				}
+
+				f32 targetYaw = MsGetRotFromZaxisY(force);
+				f32 diff      = targetYaw
+				           - MsWrap(b->unkC.y, targetYaw - 180.0f,
+				                    targetYaw + 180.0f);
+				if (diff < -0.01f)
+					diff = -unk28;
+				else if (diff > 0.01f)
+					diff = unk28;
+
+				f32 newYaw = b->unkC.y + diff;
+				while (newYaw >= 360.0f)
+					newYaw -= 360.0f;
+				while (newYaw < 0.0f)
+					newYaw += 360.0f;
+				b->unkC.y = newYaw;
+			}
+
+			Mtx m;
+			MsMtxSetRotRPH(m, b->unkC.x, b->unkC.y, b->unkC.z);
+			b->unk18.set(m[0][2], m[1][2], m[2][2]);
+			PSVECNormalize(&b->unk18, &b->unk18);
+
+			f32 speed                  = force.length();
+			JGeometry::TVec3<f32> step = b->unk18;
+			step.scale(unk20 + b->unk4C);
+			step.scale(speed);
+			b->unk0.add(step);
+		}
+	}
+}
 
 TBoid::TBoid()
 {

--- a/src/Animal/boid.cpp
+++ b/src/Animal/boid.cpp
@@ -210,26 +210,24 @@ TBoidLeader::TBoidLeader(int num, const char* name)
     : JDrama::TViewObj(name)
     , mNumBoids(num)
     , mBoids(new TBoid[num])
+    , unk18(nullptr)
+    , unk1C(0)
+    , unk20(6.0f)
+    , unk24(150.0f)
+    , unk28(2.0f)
+    , unk2C(2.0f)
+    , unk30(10.0f)
+    , unk34(0.01f)
+    , unk38(TPathNode())
+    , unk48(1.0f)
+    , unk58(0)
+    , unk5C(TPathNode())
+    , unk6C(0.0f)
+    , unk70(1.0f)
+    , unk74(0.0f)
+    , unk78(0.0f)
+    , unk7C(0.0f)
 {
-	unk18      = 0;
-	unk1C      = 0;
-	unk20      = 6.0f;
-	unk24      = 150.0f;
-	unk28      = 2.0f;
-	unk2C      = 2.0f;
-	unk30      = 10.0f;
-	unk34      = 0.01f;
-	unk38.unk0 = nullptr;
-	unk38.unk4 = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
-	unk48      = 1.0f;
-	unk58      = 0;
-	unk5C.unk0 = nullptr;
-	unk5C.unk4 = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
-	unk6C      = 0.0f;
-	unk70      = 1.0f;
-	unk74      = 0.0f;
-	unk78      = 0.0f;
-	unk7C      = 0.0f;
 	unk4C      = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
 	unk1C |= 1;
 }

--- a/src/Animal/boid.cpp
+++ b/src/Animal/boid.cpp
@@ -42,9 +42,9 @@ TBoidLeader::calcGoalForce(const JGeometry::TVec3<f32>& pos) const
 		force.setLength(1.0f);
 	} else {
 		const JGeometry::TVec3<f32>& node = unk38.getPoint();
-		force.x = node.x;
-		force.y = node.y;
-		force.z = node.z;
+		force.x                           = node.x;
+		force.y                           = node.y;
+		force.z                           = node.z;
 		force.add(unk4C);
 		force.sub(pos);
 		f32 len = force.length();
@@ -59,9 +59,7 @@ TBoidLeader::calcGoalForce(const JGeometry::TVec3<f32>& pos) const
 }
 
 // UNUSED (Size: 0x150 in MAP)
-void TBoidLeader::updateGoal()
-{
-}
+void TBoidLeader::updateGoal() { }
 
 void TBoidLeader::perform(u32 flags, JDrama::TGraphics* graphics)
 {
@@ -200,7 +198,7 @@ void TBoidLeader::calcBoids()
 			b->unk18.set(m[0][2], m[1][2], m[2][2]);
 			PSVECNormalize(&b->unk18, &b->unk18);
 
-			f32 speed                  = PSVECMag(&force);
+			f32 speed = PSVECMag(&force);
 			b->unk0 += b->unk18 * (unk20 + b->unk4C) * speed;
 		}
 	}
@@ -228,7 +226,7 @@ TBoidLeader::TBoidLeader(int num, const char* name)
     , unk78(0.0f)
     , unk7C(0.0f)
 {
-	unk4C      = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	unk4C = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
 	unk1C |= 1;
 }
 

--- a/src/Animal/boid.cpp
+++ b/src/Animal/boid.cpp
@@ -29,6 +29,33 @@ TBoidLeader::TBoidLeader(int num, const char* name)
 	unk1C |= 1;
 }
 
+TBoidLeader::~TBoidLeader() { }
+
+void TBoidLeader::setGraph(TGraphWeb* web, const JGeometry::TVec3<f32>& pos)
+{
+	if (web == nullptr)
+		return;
+	if (web->isDummy())
+		return;
+
+	if (unk18 == nullptr)
+		unk18 = new TGraphTracer();
+
+	unk18->setGraph(web);
+	unk18->setTo(web->findNearestNodeIndex(pos, 0xffffffff));
+
+	// TODO: 86.8% - logic correct; the original keeps a separate TVec3 copy of
+	// indexToPoint's by-value return that MWCC elides here (unsolved
+	// copy-count).
+	JGeometry::TVec3<f32> pt
+	    = unk18->getGraph()->indexToPoint(unk18->getCurGraphIndex());
+	unk74 = pt.x;
+	unk78 = pt.y;
+	unk7C = pt.z;
+
+	unk1C |= 4;
+}
+
 TBoid::TBoid()
 {
 	unk48 = 0;

--- a/src/Animal/boid.cpp
+++ b/src/Animal/boid.cpp
@@ -1,1 +1,42 @@
+#include <Animal/boid.hpp>
+#include <MarioUtil/RandomUtil.hpp>
 
+TBoidLeader::TBoidLeader(int num, const char* name)
+    : JDrama::TViewObj(name)
+{
+	mNumBoids = num;
+	mBoids    = new TBoid[num];
+	unk18     = 0;
+	unk1C     = 0;
+	unk20     = 6.0f;
+	unk24     = 150.0f;
+	unk28     = 2.0f;
+	unk2C     = 2.0f;
+	unk30     = 10.0f;
+	unk34     = 0.01f;
+	unk38     = 0;
+	unk3C     = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	unk48     = 1.0f;
+	unk58     = 0;
+	unk5C     = 0;
+	unk60     = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	unk6C     = 0.0f;
+	unk70     = 1.0f;
+	unk74     = 0.0f;
+	unk78     = 0.0f;
+	unk7C     = 0.0f;
+	unk4C     = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	unk1C |= 1;
+}
+
+TBoid::TBoid()
+{
+	unk48 = 0;
+	unk4C = 0.0f;
+	unk0.set(0.0f, 0.0f, 0.0f);
+	unkC.set(0.0f, 0.0f, 0.0f);
+	unk18 = 0.0f;
+	unk1C = 0.0f;
+	unk20 = 1.0f;
+	unk4C = MsRandF();
+}

--- a/src/Animal/boid.cpp
+++ b/src/Animal/boid.cpp
@@ -4,28 +4,28 @@
 TBoidLeader::TBoidLeader(int num, const char* name)
     : JDrama::TViewObj(name)
 {
-	mNumBoids = num;
-	mBoids    = new TBoid[num];
-	unk18     = 0;
-	unk1C     = 0;
-	unk20     = 6.0f;
-	unk24     = 150.0f;
-	unk28     = 2.0f;
-	unk2C     = 2.0f;
-	unk30     = 10.0f;
-	unk34     = 0.01f;
-	unk38     = 0;
-	unk3C     = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
-	unk48     = 1.0f;
-	unk58     = 0;
-	unk5C     = 0;
-	unk60     = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
-	unk6C     = 0.0f;
-	unk70     = 1.0f;
-	unk74     = 0.0f;
-	unk78     = 0.0f;
-	unk7C     = 0.0f;
-	unk4C     = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	mNumBoids  = num;
+	mBoids     = new TBoid[num];
+	unk18      = 0;
+	unk1C      = 0;
+	unk20      = 6.0f;
+	unk24      = 150.0f;
+	unk28      = 2.0f;
+	unk2C      = 2.0f;
+	unk30      = 10.0f;
+	unk34      = 0.01f;
+	unk38.unk0 = nullptr;
+	unk38.unk4 = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	unk48      = 1.0f;
+	unk58      = 0;
+	unk5C      = 0;
+	unk60      = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	unk6C      = 0.0f;
+	unk70      = 1.0f;
+	unk74      = 0.0f;
+	unk78      = 0.0f;
+	unk7C      = 0.0f;
+	unk4C      = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
 	unk1C |= 1;
 }
 
@@ -54,6 +54,31 @@ void TBoidLeader::setGraph(TGraphWeb* web, const JGeometry::TVec3<f32>& pos)
 	unk7C = pt.z;
 
 	unk1C |= 4;
+}
+
+JGeometry::TVec3<f32>
+TBoidLeader::calcGoalForce(const JGeometry::TVec3<f32>& pos) const
+{
+	// TODO: logic-complete; by-value TVec3 return hits the unsolved MWCC
+	// copy-count problem (same as getRotationFlyToDir in AnimalBase).
+	JGeometry::TVec3<f32> force;
+	if (unk1C & 4) {
+		force.set(unk74, unk78, unk7C);
+		force.sub(pos);
+		force.setLength(1.0f);
+	} else {
+		const JGeometry::TVec3<f32>& node = unk38.getPoint();
+		force.set(node.x + unk4C.x, node.y + unk4C.y, node.z + unk4C.z);
+		force.sub(pos);
+		f32 len = force.length();
+		if (len > 0.0f) {
+			force.scale(1.0f / len);
+			force.scale(unk48);
+		} else {
+			force.set(0.0f, 0.0f, 0.0f);
+		}
+	}
+	return force;
 }
 
 TBoid::TBoid()

--- a/src/Animal/boid.cpp
+++ b/src/Animal/boid.cpp
@@ -3,66 +3,38 @@
 #include <MarioUtil/RandomUtil.hpp>
 #include <dolphin/mtx.h>
 
-TBoidLeader::TBoidLeader(int num, const char* name)
-    : JDrama::TViewObj(name)
-{
-	mNumBoids  = num;
-	mBoids     = new TBoid[num];
-	unk18      = 0;
-	unk1C      = 0;
-	unk20      = 6.0f;
-	unk24      = 150.0f;
-	unk28      = 2.0f;
-	unk2C      = 2.0f;
-	unk30      = 10.0f;
-	unk34      = 0.01f;
-	unk38.unk0 = nullptr;
-	unk38.unk4 = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
-	unk48      = 1.0f;
-	unk58      = 0;
-	unk5C.unk0 = nullptr;
-	unk5C.unk4 = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
-	unk6C      = 0.0f;
-	unk70      = 1.0f;
-	unk74      = 0.0f;
-	unk78      = 0.0f;
-	unk7C      = 0.0f;
-	unk4C      = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
-	unk1C |= 1;
-}
-
 TBoidLeader::~TBoidLeader() { }
 
-void TBoidLeader::setGraph(TGraphWeb* web, const JGeometry::TVec3<f32>& pos)
+JGeometry::TVec3<f32> TBoidLeader::calcForces(const TBoid* boid) const
 {
-	if (web == nullptr)
-		return;
-	if (web->isDummy())
-		return;
+	JGeometry::TVec3<f32> force = boid->unk24;
+	force += boid->unk30 * unk34;
+	force += boid->unk3C;
+	force += calcGoalForce(boid->unk0);
 
-	if (unk18 == nullptr)
-		unk18 = new TGraphTracer();
+	if (force.squared() == 0.0f) {
+		return JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	}
 
-	unk18->setGraph(web);
-	unk18->setTo(web->findNearestNodeIndex(pos, 0xffffffff));
+	force.scale(0.01f * (5.0f * MsRandF() + 95.0f));
+	force.setLength(1.0f);
 
-	// TODO: 86.8% - logic correct; the original keeps a separate TVec3 copy of
-	// indexToPoint's by-value return that MWCC elides here (unsolved
-	// copy-count).
-	JGeometry::TVec3<f32> pt
-	    = unk18->getGraph()->indexToPoint(unk18->getCurGraphIndex());
-	unk74 = pt.x;
-	unk78 = pt.y;
-	unk7C = pt.z;
+	if (0.0f < unk6C) {
+		JGeometry::TVec3<f32> away = boid->unk0;
+		away -= unk5C.getPoint();
+		f32 d2 = away.squared();
+		if (d2 > 0.0f && d2 < unk6C * unk6C) {
+			away.setLength(unk70);
+			force = away;
+		}
+	}
 
-	unk1C |= 4;
+	return force;
 }
 
 JGeometry::TVec3<f32>
 TBoidLeader::calcGoalForce(const JGeometry::TVec3<f32>& pos) const
 {
-	// TODO: logic-complete; by-value TVec3 return hits the unsolved MWCC
-	// copy-count problem (same as getRotationFlyToDir in AnimalBase).
 	JGeometry::TVec3<f32> force;
 	if (unk1C & 4) {
 		force.set(unk74, unk78, unk7C);
@@ -70,7 +42,10 @@ TBoidLeader::calcGoalForce(const JGeometry::TVec3<f32>& pos) const
 		force.setLength(1.0f);
 	} else {
 		const JGeometry::TVec3<f32>& node = unk38.getPoint();
-		force.set(node.x + unk4C.x, node.y + unk4C.y, node.z + unk4C.z);
+		force.x = node.x;
+		force.y = node.y;
+		force.z = node.z;
+		force.add(unk4C);
 		force.sub(pos);
 		f32 len = force.length();
 		if (len > 0.0f) {
@@ -83,38 +58,9 @@ TBoidLeader::calcGoalForce(const JGeometry::TVec3<f32>& pos) const
 	return force;
 }
 
-JGeometry::TVec3<f32> TBoidLeader::calcForces(const TBoid* boid) const
+// UNUSED (Size: 0x150 in MAP)
+void TBoidLeader::updateGoal()
 {
-	// TODO: logic-complete; by-value TVec3 return hits the unsolved MWCC
-	// copy-count problem (same as getRotationFlyToDir in AnimalBase).
-	JGeometry::TVec3<f32> force(boid->unk24);
-
-	JGeometry::TVec3<f32> heading(boid->unk30);
-	heading.scale(unk34);
-	force.add(heading);
-
-	force.add(boid->unk3C);
-	force.add(calcGoalForce(boid->unk0));
-
-	if (force.squared() == 0.0f) {
-		JGeometry::TVec3<f32> zero(0.0f, 0.0f, 0.0f);
-		return zero;
-	}
-
-	force.scale(0.01f * (5.0f * MsRandF() + 95.0f));
-	force.setLength(1.0f);
-
-	if (unk6C > 0.0f) {
-		JGeometry::TVec3<f32> away(boid->unk0);
-		away.sub(unk5C.getPoint());
-		f32 d2 = away.squared();
-		if (d2 > 0.0f && d2 < unk6C * unk6C) {
-			away.setLength(unk70);
-			force = away;
-		}
-	}
-
-	return force;
 }
 
 void TBoidLeader::perform(u32 flags, JDrama::TGraphics* graphics)
@@ -143,10 +89,27 @@ void TBoidLeader::perform(u32 flags, JDrama::TGraphics* graphics)
 	}
 }
 
+void TBoidLeader::setGraph(TGraphWeb* web, const JGeometry::TVec3<f32>& pos)
+{
+	if (web != nullptr && !web->isDummy()) {
+		if (unk18 == nullptr)
+			unk18 = new TGraphTracer();
+
+		unk18->setGraph(web);
+		unk18->setTo(web->findNearestNodeIndex(pos, 0xffffffff));
+
+		const JGeometry::TVec3<f32>& pt
+		    = unk18->getGraph()->indexToPoint(unk18->getCurGraphIndex());
+		unk74 = pt.x;
+		unk78 = pt.y;
+		unk7C = pt.z;
+
+		unk1C |= 4;
+	}
+}
+
 void TBoidLeader::calcBoids()
 {
-	// TODO: logic-complete; nested pair loop over the flock. The by-value
-	// calcForces call and heavy TVec3 math leave MWCC copy-count residuals.
 	if (unk1C & 1) {
 		TBoid* end = mBoids + mNumBoids;
 
@@ -159,8 +122,8 @@ void TBoidLeader::calcBoids()
 
 		for (TBoid* i = mBoids; i != end; ++i) {
 			for (TBoid* j = i + 1; j != end; ++j) {
-				JGeometry::TVec3<f32> d;
-				d.sub(i->unk0, j->unk0);
+				JGeometry::TVec3<f32> d = i->unk0;
+				d.sub(j->unk0);
 				f32 d2 = d.squared();
 				if (d2 < 0.001f)
 					continue;
@@ -169,13 +132,11 @@ void TBoidLeader::calcBoids()
 				if (d2 < radius * radius) {
 					JGeometry::TVec3<f32> sep = d;
 					sep.div(d2);
-					sep.scale(radius);
-					i->unk24.add(sep);
+					i->unk24 += sep * radius;
 
 					JGeometry::TVec3<f32> sep2 = d;
 					sep2.div(d2);
-					sep2.scale(radius);
-					j->unk24.sub(sep2);
+					j->unk24 -= sep2 * radius;
 
 					i->unk30.add(j->unk18);
 					j->unk30.add(i->unk18);
@@ -239,13 +200,38 @@ void TBoidLeader::calcBoids()
 			b->unk18.set(m[0][2], m[1][2], m[2][2]);
 			PSVECNormalize(&b->unk18, &b->unk18);
 
-			f32 speed                  = force.length();
-			JGeometry::TVec3<f32> step = b->unk18;
-			step.scale(unk20 + b->unk4C);
-			step.scale(speed);
-			b->unk0.add(step);
+			f32 speed                  = PSVECMag(&force);
+			b->unk0 += b->unk18 * (unk20 + b->unk4C) * speed;
 		}
 	}
+}
+
+TBoidLeader::TBoidLeader(int num, const char* name)
+    : JDrama::TViewObj(name)
+    , mNumBoids(num)
+    , mBoids(new TBoid[num])
+{
+	unk18      = 0;
+	unk1C      = 0;
+	unk20      = 6.0f;
+	unk24      = 150.0f;
+	unk28      = 2.0f;
+	unk2C      = 2.0f;
+	unk30      = 10.0f;
+	unk34      = 0.01f;
+	unk38.unk0 = nullptr;
+	unk38.unk4 = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	unk48      = 1.0f;
+	unk58      = 0;
+	unk5C.unk0 = nullptr;
+	unk5C.unk4 = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	unk6C      = 0.0f;
+	unk70      = 1.0f;
+	unk74      = 0.0f;
+	unk78      = 0.0f;
+	unk7C      = 0.0f;
+	unk4C      = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	unk1C |= 1;
 }
 
 TBoid::TBoid()

--- a/src/Animal/boid.cpp
+++ b/src/Animal/boid.cpp
@@ -18,8 +18,8 @@ TBoidLeader::TBoidLeader(int num, const char* name)
 	unk38.unk4 = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
 	unk48      = 1.0f;
 	unk58      = 0;
-	unk5C      = 0;
-	unk60      = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
+	unk5C.unk0 = nullptr;
+	unk5C.unk4 = JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f);
 	unk6C      = 0.0f;
 	unk70      = 1.0f;
 	unk74      = 0.0f;
@@ -78,6 +78,40 @@ TBoidLeader::calcGoalForce(const JGeometry::TVec3<f32>& pos) const
 			force.set(0.0f, 0.0f, 0.0f);
 		}
 	}
+	return force;
+}
+
+JGeometry::TVec3<f32> TBoidLeader::calcForces(const TBoid* boid) const
+{
+	// TODO: logic-complete; by-value TVec3 return hits the unsolved MWCC
+	// copy-count problem (same as getRotationFlyToDir in AnimalBase).
+	JGeometry::TVec3<f32> force(boid->unk24);
+
+	JGeometry::TVec3<f32> heading(boid->unk30);
+	heading.scale(unk34);
+	force.add(heading);
+
+	force.add(boid->unk3C);
+	force.add(calcGoalForce(boid->unk0));
+
+	if (force.squared() == 0.0f) {
+		JGeometry::TVec3<f32> zero(0.0f, 0.0f, 0.0f);
+		return zero;
+	}
+
+	force.scale(0.01f * (5.0f * MsRandF() + 95.0f));
+	force.setLength(1.0f);
+
+	if (unk6C > 0.0f) {
+		JGeometry::TVec3<f32> away(boid->unk0);
+		away.sub(unk5C.getPoint());
+		f32 d2 = away.squared();
+		if (d2 > 0.0f && d2 < unk6C * unk6C) {
+			away.setLength(unk70);
+			force = away;
+		}
+	}
+
 	return force;
 }
 

--- a/src/Animal/boid.cpp
+++ b/src/Animal/boid.cpp
@@ -1,5 +1,6 @@
 #include <Animal/boid.hpp>
 #include <MarioUtil/RandomUtil.hpp>
+#include <dolphin/mtx.h>
 
 TBoidLeader::TBoidLeader(int num, const char* name)
     : JDrama::TViewObj(name)
@@ -115,14 +116,40 @@ JGeometry::TVec3<f32> TBoidLeader::calcForces(const TBoid* boid) const
 	return force;
 }
 
+void TBoidLeader::perform(u32 flags, JDrama::TGraphics* graphics)
+{
+	if (flags & 2) {
+		if (unk1C & 4) {
+			JGeometry::TVec3<f32> dir
+			    = unk18->getGraph()->indexToPoint(unk18->getCurGraphIndex());
+			dir.x -= unk74;
+			dir.y -= unk78;
+			dir.z -= unk7C;
+			if (dir.squared() < 10000.0f) {
+				unk18->moveTo(unk18->getGraph()->getRandomNextIndex(
+				    unk18->getCurGraphIndex(), unk18->getPrevIndex(),
+				    0xffffffff));
+			} else {
+				PSVECNormalize(&dir, &dir);
+				f32 step = 0.9f * unk20;
+				dir.scale(step);
+				unk74 += dir.x;
+				unk78 += dir.y;
+				unk7C += dir.z;
+			}
+		}
+		calcBoids();
+	}
+}
+
+void TBoidLeader::calcBoids() { }
+
 TBoid::TBoid()
 {
 	unk48 = 0;
 	unk4C = 0.0f;
 	unk0.set(0.0f, 0.0f, 0.0f);
 	unkC.set(0.0f, 0.0f, 0.0f);
-	unk18 = 0.0f;
-	unk1C = 0.0f;
-	unk20 = 1.0f;
+	unk18.set(0.0f, 0.0f, 1.0f);
 	unk4C = MsRandF();
 }

--- a/src/Animal/fishoid.cpp
+++ b/src/Animal/fishoid.cpp
@@ -1,4 +1,6 @@
 #include <Animal/fishoid.hpp>
+#include <M3DUtil/MActor.hpp>
+#include <Player/MarioAccess.hpp>
 
 TRealoid::TRealoid(const char* name)
     : TSpineEnemy(name)
@@ -7,9 +9,38 @@ TRealoid::TRealoid(const char* name)
 	mLiveFlag |= 0x38;
 }
 
+TRealoid::~TRealoid() { }
+
 TRealoidActor::TRealoidActor(MActor* actor)
     : TTakeActor("boid")
 {
 	unk70 = actor;
 	unk74 = 0;
+}
+
+TRealoidActor::~TRealoidActor() { }
+
+MtxPtr TRealoidActor::getTakingMtx() { return unk78; }
+
+void TRealoidActor::checkHitActors()
+{
+	if (unk74 & 6)
+		return;
+
+	THitActor** it  = mCollisions;
+	THitActor** end = mCollisions + mColCount;
+	for (; it != end; ++it) {
+		if ((*it)->getActorType() == 0x80000001)
+			SMS_SendMessageToMario(this, 0xE);
+	}
+}
+
+void TRealoidActor::perform(u32 flags, JDrama::TGraphics* graphics)
+{
+	if (unk74 & 6)
+		return;
+
+	THitActor::perform(flags, graphics);
+	if (!(unk74 & 1))
+		unk70->perform(flags, graphics);
 }

--- a/src/Animal/fishoid.cpp
+++ b/src/Animal/fishoid.cpp
@@ -51,7 +51,7 @@ void TRealoidActor::calcRootMatrix(TBoid* boid)
 	mPosition = boid->unk0;
 
 	if (mHolder != nullptr) {
-		MtxPtr hm = mHolder->getTakingMtx();
+		MtxPtr hm    = mHolder->getTakingMtx();
 		boid->unk0.x = hm[0][3];
 		boid->unk0.y = hm[1][3];
 		boid->unk0.z = hm[2][3];
@@ -82,18 +82,18 @@ void TRealoidActor::calcRootMatrix(TBoid* boid)
 	PSVECNormalize(&dir, &dir);
 
 	MtxPtr root = unk70->getModel()->unk20;
-	root[0][0] = -dir.x;
-	root[1][0] = -dir.y;
-	root[2][0] = -dir.z;
-	root[0][1] = up.x;
-	root[1][1] = up.y;
-	root[2][1] = up.z;
-	root[0][2] = n.x;
-	root[1][2] = n.y;
-	root[2][2] = n.z;
-	root[0][3] = trans.x;
-	root[1][3] = trans.y;
-	root[2][3] = trans.z;
+	root[0][0]  = -dir.x;
+	root[1][0]  = -dir.y;
+	root[2][0]  = -dir.z;
+	root[0][1]  = up.x;
+	root[1][1]  = up.y;
+	root[2][1]  = up.z;
+	root[0][2]  = n.x;
+	root[1][2]  = n.y;
+	root[2][2]  = n.z;
+	root[0][3]  = trans.x;
+	root[1][3]  = trans.y;
+	root[2][3]  = trans.z;
 }
 
 void TRealoidActor::checkHitActors()
@@ -119,7 +119,7 @@ TRealoid::TRealoid(const char* name)
 }
 
 void TRealoid::loadDefault(JSUMemoryInputStream& stream, const char* name,
-                          int arg2)
+                           int arg2)
 {
 	// TODO: 89.9% - logic exact. Residual = frame padding + TPathNode setup
 	// staged via stack (struct-copy) + regalloc cascade.

--- a/src/Animal/fishoid.cpp
+++ b/src/Animal/fishoid.cpp
@@ -19,37 +19,15 @@ const char* cFishoidMdlNames[]
     = { "fishA.bmd", "fishB.bmd", "fishC.bmd", "fishD.bmd" };
 } // namespace
 
-TRealoid::TRealoid(const char* name)
-    : TSpineEnemy(name)
-{
-	unk150 = 0;
-	mLiveFlag |= 0x38;
-}
+TFish::~TFish() { }
 
-TRealoid::~TRealoid() { }
+TFishoid::~TFishoid() { }
 
 TRealoidActor::TRealoidActor(MActor* actor)
     : TTakeActor("boid")
 {
 	unk70 = actor;
 	unk74 = 0;
-}
-
-TRealoidActor::~TRealoidActor() { }
-
-MtxPtr TRealoidActor::getTakingMtx() { return unk78; }
-
-void TRealoidActor::checkHitActors()
-{
-	if (unk74 & 6)
-		return;
-
-	THitActor** it  = mCollisions;
-	THitActor** end = mCollisions + mColCount;
-	for (; it != end; ++it) {
-		if ((*it)->getActorType() == 0x80000001)
-			SMS_SendMessageToMario(this, 0xE);
-	}
 }
 
 void TRealoidActor::perform(u32 flags, JDrama::TGraphics* graphics)
@@ -60,68 +38,6 @@ void TRealoidActor::perform(u32 flags, JDrama::TGraphics* graphics)
 	THitActor::perform(flags, graphics);
 	if (!(unk74 & 1))
 		unk70->perform(flags, graphics);
-}
-
-void TRealoid::clipBoids(JDrama::TGraphics* graphics)
-{
-	// TODO: 97.2% - logic exact; retail frame +0x30 (inline) + induction-var
-	// regalloc numbering differ. Not a fakematch; leave as-is.
-	SetViewFrustumClipCheckPerspective(gpCamera->mFovy, gpCamera->getAspect(),
-	                                   graphics->mNearPlane, 10000.0f);
-
-	for (int i = 0; i < unk150->mNumBoids; ++i) {
-		JGeometry::TVec3<f32> pos = unk150->mBoids[i].unk0;
-		if (ViewFrustumClipCheck(graphics, &pos, 100.0f))
-			unk154[i]->unk74 &= ~1;
-		else
-			unk154[i]->unk74 |= 1;
-	}
-}
-
-void TRealoid::loadDefault(JSUMemoryInputStream& stream, const char* name,
-                          int arg2)
-{
-	// TODO: 89.9% - logic exact. Residual = frame padding + TPathNode setup
-	// staged via stack (struct-copy) + regalloc cascade.
-	TSpineEnemy::load(stream);
-
-	int count;
-	stream.read(&count, 4);
-
-	mMActorKeeper = new TMActorKeeper(mManager, count + arg2);
-	unk150        = new TBoidLeader(count, "コントローラ");
-
-	unk150->unk38.unk0 = nullptr;
-	unk150->unk38.unk4 = mPosition;
-
-	unk150->setGraph(unk124->getGraph(), mPosition);
-
-	unk154 = new TRealoidActor*[count];
-
-	JGeometry::TVec3<f32> pos = mPosition;
-	for (int i = 0; i < count; ++i) {
-		MActor* actor = mMActorKeeper->createMActor(name, 3);
-		TBoid* boid   = &unk150->mBoids[i];
-		boid->unk0    = pos;
-		unk154[i]     = createRealoidActor(actor);
-		pos.y += 10.0f;
-	}
-}
-
-void TRealoid::perform(u32 flags, JDrama::TGraphics* graphics)
-{
-	// TODO: 92.7% - inlines clipBoids; residual inherits clipBoids' frame/
-	// regalloc padding wall.
-	unk150->perform(flags, graphics);
-
-	if (flags & 2) {
-		clipBoids(graphics);
-		for (int i = 0; i < unk150->mNumBoids; ++i)
-			unk154[i]->calcRootMatrix(&unk150->mBoids[i]);
-	}
-
-	for (int i = 0; i < unk150->mNumBoids; ++i)
-		unk154[i]->perform(flags, graphics);
 }
 
 void TRealoidActor::calcRootMatrix(TBoid* boid)
@@ -180,40 +96,93 @@ void TRealoidActor::calcRootMatrix(TBoid* boid)
 	root[2][3] = trans.z;
 }
 
-TFishoidManager::TFishoidManager(const char* name)
-    : TEnemyManager(name)
+void TRealoidActor::checkHitActors()
 {
+	if (unk74 & 6)
+		return;
+
+	THitActor** it  = mCollisions;
+	THitActor** end = mCollisions + mColCount;
+	for (; it != end; ++it) {
+		if ((*it)->getActorType() == 0x80000001)
+			SMS_SendMessageToMario(this, 0xE);
+	}
 }
 
-TFishoidManager::~TFishoidManager() { }
+MtxPtr TRealoidActor::getTakingMtx() { return unk78; }
 
-void TFishoidManager::createModelData()
+TRealoid::TRealoid(const char* name)
+    : TSpineEnemy(name)
 {
-	static TModelDataLoadEntry entry[] = {
-		{ "fishA.bmd",
-		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
-		      | (1 << J3DMLF_TevStageNumShift),
-		  0 },
-		{ "fishB.bmd",
-		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
-		      | (1 << J3DMLF_TevStageNumShift),
-		  0 },
-		{ "fishC.bmd",
-		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
-		      | (1 << J3DMLF_TevStageNumShift),
-		  0 },
-		{ "fishD.bmd",
-		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
-		      | (1 << J3DMLF_TevStageNumShift),
-		  0 },
-		{ nullptr, 0, 0 },
-	};
-	createModelDataArray(entry);
+	unk150 = 0;
+	mLiveFlag |= 0x38;
 }
 
-TFish::~TFish() { }
+void TRealoid::loadDefault(JSUMemoryInputStream& stream, const char* name,
+                          int arg2)
+{
+	// TODO: 89.9% - logic exact. Residual = frame padding + TPathNode setup
+	// staged via stack (struct-copy) + regalloc cascade.
+	TSpineEnemy::load(stream);
+
+	int count;
+	stream.read(&count, 4);
+
+	mMActorKeeper = new TMActorKeeper(mManager, count + arg2);
+	unk150        = new TBoidLeader(count, "コントローラ");
+
+	unk150->unk38.unk0 = nullptr;
+	unk150->unk38.unk4 = mPosition;
+
+	unk150->setGraph(unk124->getGraph(), mPosition);
+
+	unk154 = new TRealoidActor*[count];
+
+	JGeometry::TVec3<f32> pos = mPosition;
+	for (int i = 0; i < count; ++i) {
+		MActor* actor = mMActorKeeper->createMActor(name, 3);
+		TBoid* boid   = &unk150->mBoids[i];
+		boid->unk0    = pos;
+		unk154[i]     = createRealoidActor(actor);
+		pos.y += 10.0f;
+	}
+}
+
+void TRealoid::clipBoids(JDrama::TGraphics* graphics)
+{
+	// TODO: 97.2% - logic exact; retail frame +0x30 (inline) + induction-var
+	// regalloc numbering differ. Not a fakematch; leave as-is.
+	SetViewFrustumClipCheckPerspective(gpCamera->mFovy, gpCamera->getAspect(),
+	                                   graphics->mNearPlane, 10000.0f);
+
+	for (int i = 0; i < unk150->mNumBoids; ++i) {
+		JGeometry::TVec3<f32> pos = unk150->mBoids[i].unk0;
+		if (ViewFrustumClipCheck(graphics, &pos, 100.0f))
+			unk154[i]->unk74 &= ~1;
+		else
+			unk154[i]->unk74 |= 1;
+	}
+}
+
+void TRealoid::perform(u32 flags, JDrama::TGraphics* graphics)
+{
+	// TODO: 92.7% - inlines clipBoids; residual inherits clipBoids' frame/
+	// regalloc padding wall.
+	unk150->perform(flags, graphics);
+
+	if (flags & 2) {
+		clipBoids(graphics);
+		for (int i = 0; i < unk150->mNumBoids; ++i)
+			unk154[i]->calcRootMatrix(&unk150->mBoids[i]);
+	}
+
+	for (int i = 0; i < unk150->mNumBoids; ++i)
+		unk154[i]->perform(flags, graphics);
+}
 
 void TFish::init() { mHitFlags |= 1; }
+
+TRealoid::~TRealoid() { }
 
 TFishoid::TFishoid(int arg0, const char* name)
     : TRealoid(name)
@@ -222,12 +191,24 @@ TFishoid::TFishoid(int arg0, const char* name)
 	unk15C = nullptr;
 }
 
-TFishoid::~TFishoid() { }
-
-TRealoidActor* TFishoid::createRealoidActor(MActor* actor)
+void TFishoid::perform(u32 flags, JDrama::TGraphics* graphics)
 {
-	// TODO: 71.9% - inlines TFish/TRealoidActor ctor; residual is regalloc
-	return new TFish(actor);
+	// TODO: 81.3% - inlines TRealoid::perform; residual = frame/regalloc.
+	TRealoid::perform(flags, graphics);
+
+	for (int i = 0; i < unk150->mNumBoids; ++i) {
+		JGeometry::TVec3<f32> pos = unk150->mBoids[i].unk0;
+		if (pos.y > 0.0f)
+			pos.y = 0.0f;
+		unk150->mBoids[i].unk0 = pos;
+	}
+
+	if (unk15C != nullptr && (flags & 1)) {
+		TBoid& last         = unk150->mBoids[unk150->mNumBoids - 1];
+		unk15C->mPosition.x = last.unk0.x;
+		unk15C->mPosition.y = last.unk0.y;
+		unk15C->mPosition.z = last.unk0.z;
+	}
 }
 
 void TFishoid::init(TLiveManager* manager)
@@ -274,22 +255,41 @@ void TFishoid::load(JSUMemoryInputStream& stream)
 		unk154[i]->unk70->setBck("fish_swim");
 }
 
-void TFishoid::perform(u32 flags, JDrama::TGraphics* graphics)
+TRealoidActor::~TRealoidActor() { }
+
+TRealoidActor* TFishoid::createRealoidActor(MActor* actor)
 {
-	// TODO: 81.3% - inlines TRealoid::perform; residual = frame/regalloc.
-	TRealoid::perform(flags, graphics);
-
-	for (int i = 0; i < unk150->mNumBoids; ++i) {
-		JGeometry::TVec3<f32> pos = unk150->mBoids[i].unk0;
-		if (pos.y > 0.0f)
-			pos.y = 0.0f;
-		unk150->mBoids[i].unk0 = pos;
-	}
-
-	if (unk15C != nullptr && (flags & 1)) {
-		TBoid& last          = unk150->mBoids[unk150->mNumBoids - 1];
-		unk15C->mPosition.x = last.unk0.x;
-		unk15C->mPosition.y = last.unk0.y;
-		unk15C->mPosition.z = last.unk0.z;
-	}
+	// TODO: 71.9% - inlines TFish/TRealoidActor ctor; residual is regalloc
+	return new TFish(actor);
 }
+
+TFishoidManager::TFishoidManager(const char* name)
+    : TEnemyManager(name)
+{
+}
+
+void TFishoidManager::createModelData()
+{
+	static TModelDataLoadEntry entry[] = {
+		{ "fishA.bmd",
+		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
+		      | (1 << J3DMLF_TevStageNumShift),
+		  0 },
+		{ "fishB.bmd",
+		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
+		      | (1 << J3DMLF_TevStageNumShift),
+		  0 },
+		{ "fishC.bmd",
+		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
+		      | (1 << J3DMLF_TevStageNumShift),
+		  0 },
+		{ "fishD.bmd",
+		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
+		      | (1 << J3DMLF_TevStageNumShift),
+		  0 },
+		{ nullptr, 0, 0 },
+	};
+	createModelDataArray(entry);
+}
+
+TFishoidManager::~TFishoidManager() { }

--- a/src/Animal/fishoid.cpp
+++ b/src/Animal/fishoid.cpp
@@ -1,12 +1,23 @@
 #include <Animal/fishoid.hpp>
 #include <Animal/boid.hpp>
 #include <Camera/Camera.hpp>
+#include <Enemy/Launcher.hpp>
 #include <JSystem/J3D/J3DGraphLoader/J3DModelLoaderFlags.hpp>
 #include <M3DUtil/MActor.hpp>
 #include <MarioUtil/DrawUtil.hpp>
+#include <MoveBG/Item.hpp>
+#include <MoveBG/ItemManager.hpp>
+#include <MoveBG/MapObjBase.hpp>
+#include <MoveBG/MapObjManager.hpp>
 #include <Player/MarioAccess.hpp>
 #include <Strategic/ObjManager.hpp>
 #include <Strategic/ObjModel.hpp>
+#include <Strategic/Spine.hpp>
+
+namespace {
+const char* cFishoidMdlNames[]
+    = { "fishA.bmd", "fishB.bmd", "fishC.bmd", "fishD.bmd" };
+} // namespace
 
 TRealoid::TRealoid(const char* name)
     : TSpineEnemy(name)
@@ -198,4 +209,87 @@ void TFishoidManager::createModelData()
 		{ nullptr, 0, 0 },
 	};
 	createModelDataArray(entry);
+}
+
+TFish::~TFish() { }
+
+void TFish::init() { mHitFlags |= 1; }
+
+TFishoid::TFishoid(int arg0, const char* name)
+    : TRealoid(name)
+{
+	unk158 = arg0;
+	unk15C = nullptr;
+}
+
+TFishoid::~TFishoid() { }
+
+TRealoidActor* TFishoid::createRealoidActor(MActor* actor)
+{
+	// TODO: 71.9% - inlines TFish/TRealoidActor ctor; residual is regalloc
+	return new TFish(actor);
+}
+
+void TFishoid::init(TLiveManager* manager)
+{
+	mManager = manager;
+	mManager->manageActor(this);
+	mSpine->initWith(&TNerveWaitForever<TLiveActor>::theNerve());
+	initHitActor(0, 1, 0, 0.0f, 0.0f, 0.0f, 0.0f);
+	mHitFlags |= 1;
+}
+
+void TFishoid::load(JSUMemoryInputStream& stream)
+{
+	// TODO: 66.2% - logic drafted; residual + coin-type check (0x2000000E) and
+	// scheduling need refinement.
+	loadDefault(stream, cFishoidMdlNames[unk158], 0);
+
+	u32 eventId;
+	stream.read(&eventId, 4);
+
+	unk15C = TMapObjBaseManager::newAndRegisterObjByEventID(eventId, "");
+	if (unk15C != nullptr) {
+		if (unk15C->getActorType() == 0x2000000E)
+			unk15C = gpItemManager->newAndRegisterCoinReal();
+	}
+
+	unk150->unk20 = 4.0f;
+	unk150->unk24 = 200.0f;
+	unk150->unk28 = 1.0f;
+	unk150->unk2C = 0.5f;
+	unk150->unk30 = 5.0f;
+	unk150->unk34 = 0.5f;
+
+	JGeometry::TVec3<f32> mpos;
+	SMS_GetMarioPosStupid(&mpos);
+	unk150->unk5C.unk0 = (THitActor*)gpMarioAddress;
+	unk150->unk5C.unk4 = mpos;
+
+	unk150->unk6C = 400.0f;
+	unk150->unk70 = 3.0f;
+	unk150->unk1C |= 2;
+
+	for (int i = 0; i < unk150->mNumBoids; ++i)
+		unk154[i]->unk70->setBck("fish_swim");
+}
+
+void TFishoid::perform(u32 flags, JDrama::TGraphics* graphics)
+{
+	// TODO: 81.3% - inlines TRealoid::perform; residual = frame/regalloc.
+	TRealoid::perform(flags, graphics);
+
+	for (int i = 0; i < unk150->mNumBoids; ++i) {
+		JGeometry::TVec3<f32> pos = unk150->mBoids[i].unk0;
+		if (pos.y > 0.0f)
+			pos.y = 0.0f;
+		unk150->mBoids[i].unk0 = pos;
+	}
+
+	if (unk15C != nullptr && (flags & 1)) {
+		TBoid& last          = unk150->mBoids[unk150->mNumBoids - 1];
+		unk15C->mPosition.x = last.unk0.x;
+		unk15C->mPosition.y = last.unk0.y;
+		unk15C->mPosition.z = last.unk0.z;
+	}
 }

--- a/src/Animal/fishoid.cpp
+++ b/src/Animal/fishoid.cpp
@@ -6,6 +6,7 @@
 #include <MarioUtil/DrawUtil.hpp>
 #include <Player/MarioAccess.hpp>
 #include <Strategic/ObjManager.hpp>
+#include <Strategic/ObjModel.hpp>
 
 TRealoid::TRealoid(const char* name)
     : TSpineEnemy(name)
@@ -63,6 +64,36 @@ void TRealoid::clipBoids(JDrama::TGraphics* graphics)
 			unk154[i]->unk74 &= ~1;
 		else
 			unk154[i]->unk74 |= 1;
+	}
+}
+
+void TRealoid::loadDefault(JSUMemoryInputStream& stream, const char* name,
+                          int arg2)
+{
+	// TODO: 89.9% - logic exact. Residual = frame padding + TPathNode setup
+	// staged via stack (struct-copy) + regalloc cascade.
+	TSpineEnemy::load(stream);
+
+	int count;
+	stream.read(&count, 4);
+
+	mMActorKeeper = new TMActorKeeper(mManager, count + arg2);
+	unk150        = new TBoidLeader(count, "コントローラ");
+
+	unk150->unk38.unk0 = nullptr;
+	unk150->unk38.unk4 = mPosition;
+
+	unk150->setGraph(unk124->getGraph(), mPosition);
+
+	unk154 = new TRealoidActor*[count];
+
+	JGeometry::TVec3<f32> pos = mPosition;
+	for (int i = 0; i < count; ++i) {
+		MActor* actor = mMActorKeeper->createMActor(name, 3);
+		TBoid* boid   = &unk150->mBoids[i];
+		boid->unk0    = pos;
+		unk154[i]     = createRealoidActor(actor);
+		pos.y += 10.0f;
 	}
 }
 

--- a/src/Animal/fishoid.cpp
+++ b/src/Animal/fishoid.cpp
@@ -1,1 +1,15 @@
+#include <Animal/fishoid.hpp>
 
+TRealoid::TRealoid(const char* name)
+    : TSpineEnemy(name)
+{
+	unk150 = 0;
+	mLiveFlag |= 0x38;
+}
+
+TRealoidActor::TRealoidActor(MActor* actor)
+    : TTakeActor("boid")
+{
+	unk70 = actor;
+	unk74 = 0;
+}

--- a/src/Animal/fishoid.cpp
+++ b/src/Animal/fishoid.cpp
@@ -66,6 +66,22 @@ void TRealoid::clipBoids(JDrama::TGraphics* graphics)
 	}
 }
 
+void TRealoid::perform(u32 flags, JDrama::TGraphics* graphics)
+{
+	// TODO: 92.7% - inlines clipBoids; residual inherits clipBoids' frame/
+	// regalloc padding wall.
+	unk150->perform(flags, graphics);
+
+	if (flags & 2) {
+		clipBoids(graphics);
+		for (int i = 0; i < unk150->mNumBoids; ++i)
+			unk154[i]->calcRootMatrix(&unk150->mBoids[i]);
+	}
+
+	for (int i = 0; i < unk150->mNumBoids; ++i)
+		unk154[i]->perform(flags, graphics);
+}
+
 void TRealoidActor::calcRootMatrix(TBoid* boid)
 {
 	// TODO: 91.6% - logic exact (look-at basis from boid dir). Residual =

--- a/src/Animal/fishoid.cpp
+++ b/src/Animal/fishoid.cpp
@@ -1,6 +1,11 @@
 #include <Animal/fishoid.hpp>
+#include <Animal/boid.hpp>
+#include <Camera/Camera.hpp>
+#include <JSystem/J3D/J3DGraphLoader/J3DModelLoaderFlags.hpp>
 #include <M3DUtil/MActor.hpp>
+#include <MarioUtil/DrawUtil.hpp>
 #include <Player/MarioAccess.hpp>
+#include <Strategic/ObjManager.hpp>
 
 TRealoid::TRealoid(const char* name)
     : TSpineEnemy(name)
@@ -43,4 +48,51 @@ void TRealoidActor::perform(u32 flags, JDrama::TGraphics* graphics)
 	THitActor::perform(flags, graphics);
 	if (!(unk74 & 1))
 		unk70->perform(flags, graphics);
+}
+
+void TRealoid::clipBoids(JDrama::TGraphics* graphics)
+{
+	// TODO: 97.2% - logic exact; retail frame +0x30 (inline) + induction-var
+	// regalloc numbering differ. Not a fakematch; leave as-is.
+	SetViewFrustumClipCheckPerspective(gpCamera->mFovy, gpCamera->getAspect(),
+	                                   graphics->mNearPlane, 10000.0f);
+
+	for (int i = 0; i < unk150->mNumBoids; ++i) {
+		JGeometry::TVec3<f32> pos = unk150->mBoids[i].unk0;
+		if (ViewFrustumClipCheck(graphics, &pos, 100.0f))
+			unk154[i]->unk74 &= ~1;
+		else
+			unk154[i]->unk74 |= 1;
+	}
+}
+
+TFishoidManager::TFishoidManager(const char* name)
+    : TEnemyManager(name)
+{
+}
+
+TFishoidManager::~TFishoidManager() { }
+
+void TFishoidManager::createModelData()
+{
+	static TModelDataLoadEntry entry[] = {
+		{ "fishA.bmd",
+		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
+		      | (1 << J3DMLF_TevStageNumShift),
+		  0 },
+		{ "fishB.bmd",
+		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
+		      | (1 << J3DMLF_TevStageNumShift),
+		  0 },
+		{ "fishC.bmd",
+		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
+		      | (1 << J3DMLF_TevStageNumShift),
+		  0 },
+		{ "fishD.bmd",
+		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
+		      | (1 << J3DMLF_TevStageNumShift),
+		  0 },
+		{ nullptr, 0, 0 },
+	};
+	createModelDataArray(entry);
 }

--- a/src/Animal/fishoid.cpp
+++ b/src/Animal/fishoid.cpp
@@ -66,6 +66,62 @@ void TRealoid::clipBoids(JDrama::TGraphics* graphics)
 	}
 }
 
+void TRealoidActor::calcRootMatrix(TBoid* boid)
+{
+	// TODO: 91.6% - logic exact (look-at basis from boid dir). Residual =
+	// retail frame padding + stfsu streaming matrix stores + holder-branch
+	// model-mtx recompute. Not a fakematch.
+	if (unk74 & 6)
+		return;
+
+	mPosition = boid->unk0;
+
+	if (mHolder != nullptr) {
+		MtxPtr hm = mHolder->getTakingMtx();
+		boid->unk0.x = hm[0][3];
+		boid->unk0.y = hm[1][3];
+		boid->unk0.z = hm[2][3];
+		PSMTXCopy(mHolder->getTakingMtx(), unk70->getModel()->unk20);
+		return;
+	}
+
+	mPosition = boid->unk0;
+
+	JGeometry::TVec3<f32> trans = boid->unk0;
+	JGeometry::TVec3<f32> up(0.0f, 1.0f, 0.0f);
+	JGeometry::TVec3<f32> dir = boid->unk18;
+	JGeometry::TVec3<f32> n;
+
+	n.x = up.y * dir.z - up.z * dir.y;
+	n.y = up.z * dir.x - up.x * dir.z;
+	n.z = up.x * dir.y - up.y * dir.x;
+	PSVECNormalize(&n, &n);
+
+	up.x = dir.y * n.z - dir.z * n.y;
+	up.y = dir.z * n.x - dir.x * n.z;
+	up.z = dir.x * n.y - dir.y * n.x;
+	PSVECNormalize(&up, &up);
+
+	dir.x = n.y * up.z - n.z * up.y;
+	dir.y = n.z * up.x - n.x * up.z;
+	dir.z = n.x * up.y - n.y * up.x;
+	PSVECNormalize(&dir, &dir);
+
+	MtxPtr root = unk70->getModel()->unk20;
+	root[0][0] = -dir.x;
+	root[1][0] = -dir.y;
+	root[2][0] = -dir.z;
+	root[0][1] = up.x;
+	root[1][1] = up.y;
+	root[2][1] = up.z;
+	root[0][2] = n.x;
+	root[1][2] = n.y;
+	root[2][2] = n.z;
+	root[0][3] = trans.x;
+	root[1][3] = trans.y;
+	root[2][3] = trans.z;
+}
+
 TFishoidManager::TFishoidManager(const char* name)
     : TEnemyManager(name)
 {


### PR DESCRIPTION
Decompiles three functions from scratch in the previously-empty `src/Animal/AnimalBase.cpp`:

- `TAnimalBase(u32, const char*)` — calls base `TSpineEnemy(name)`, then stores the actor-type arg into `mActorType` (0x4c).
- `receiveMessage(THitActor*, u32)` — unhandled, returns 0.
- `calcRootMatrix()` — empty override.

All three verified at 100% via `tools/decomp-diff.py`; full build still produces `mario.dol: OK`. No stack-padding tricks. The file stays `NonMatching` since it is only 3 of ~18 functions — small honest progress rather than fakematches. Game code only (no JSystem).