### PR TITLE
Match Enemy/egggen and Enemy/generator (2 TUs)

### DIFF
--- a/include/Enemy/EggGen.hpp
+++ b/include/Enemy/EggGen.hpp
@@ -1,0 +1,23 @@
+#ifndef ENEMY_EGGGEN_HPP
+#define ENEMY_EGGGEN_HPP
+
+#include <Enemy/Enemy.hpp>
+#include <Enemy/EnemyManager.hpp>
+
+class TEggGenerator : public TSpineEnemy {
+public:
+	TEggGenerator(const char*);
+
+	virtual void init(TLiveManager*);
+	virtual void control();
+};
+
+class TEggGenManager : public TEnemyManager {
+public:
+	TEggGenManager(const char*);
+
+	virtual void load(JSUMemoryInputStream&);
+	virtual void createModelData();
+};
+
+#endif

--- a/include/Enemy/Generator.hpp
+++ b/include/Enemy/Generator.hpp
@@ -3,12 +3,25 @@
 
 #include <Strategic/HitActor.hpp>
 
+class TEnemyManager;
+class TGraphWeb;
+
 class TGenerator : public JDrama::TViewObj {
 public:
 	TGenerator(const char* name = "<TGenerator>");
 
 	virtual void load(JSUMemoryInputStream& stream);
 	virtual void perform(u32, JDrama::TGraphics*);
+
+public:
+	/* 0x10 */ JGeometry::TVec3<f32> mPos;
+	/* 0x1C */ JGeometry::TVec3<f32> mRot;
+	/* 0x28 */ const char* mManagerName;
+	/* 0x2C */ TEnemyManager* mManager;
+	/* 0x30 */ const char* mGraphName;
+	/* 0x34 */ TGraphWeb* mGraph;
+	/* 0x38 */ s32 mInterval;
+	/* 0x3C */ s32 mTimer;
 };
 
 class TOneShotGenerator : public THitActor {
@@ -18,6 +31,13 @@ public:
 	virtual void load(JSUMemoryInputStream& stream);
 	virtual void loadAfter();
 	virtual BOOL receiveMessage(THitActor* sender, u32 message);
+
+public:
+	/* 0x68 */ const char* mManagerName;
+	/* 0x6C */ TEnemyManager* mManager;
+	/* 0x70 */ const char* mGraphName;
+	/* 0x74 */ TGraphWeb* mGraph;
+	/* 0x78 */ s32 mCount;
 };
 
 #endif

--- a/src/Enemy/egggen.cpp
+++ b/src/Enemy/egggen.cpp
@@ -1,1 +1,66 @@
+#include <Enemy/EggGen.hpp>
+#include <JSystem/J3D/J3DGraphLoader/J3DModelLoaderFlags.hpp>
+#include <M3DUtil/MActor.hpp>
+#include <Player/Mario.hpp>
+#include <Player/Yoshi.hpp>
+#include <Strategic/ObjManager.hpp>
+#include <Strategic/ObjModel.hpp>
+#include <dolphin/mtx.h>
 
+TEggGenerator::TEggGenerator(const char* name)
+    : TSpineEnemy(name)
+{
+	mLiveFlag |= 0x10;
+	mLiveFlag |= 8;
+}
+
+void TEggGenerator::init(TLiveManager* manager)
+{
+	// TODO: 99.9% - byte-exact logic; residual is MWCC stack-padding (+8).
+	mManager = manager;
+	mManager->manageActor(this);
+	mMActorKeeper = new TMActorKeeper(mManager, 1);
+	mMActor       = mMActorKeeper->createMActor("gene_egg_model1.bmd", 0);
+	initHitActor(0x02000001, 1, 0x80000000, 10.0f, 10.0f, 10.0f, 10.0f);
+	mMActor->setBckFromIndex(0);
+
+	f32 angle = mRotation.x - 90.0f;
+	while (angle >= 360.0f)
+		angle -= 360.0f;
+	while (angle < 0.0f)
+		angle += 360.0f;
+	mRotation.x = angle;
+}
+
+void TEggGenerator::control()
+{
+	// TODO: 99.8% - byte-exact logic; residual is MWCC stack-padding (+0x18).
+	if (PSVECSquareDistance(&mPosition, &gpMarioOriginal->mPosition)
+	    < 250000.0f) {
+		if (!gpMarioOriginal->mYoshi->isHatched())
+			mMActor->setBckFromIndex(0);
+	}
+}
+
+TEggGenManager::TEggGenManager(const char* name)
+    : TEnemyManager(name)
+{
+}
+
+void TEggGenManager::createModelData()
+{
+	static TModelDataLoadEntry entry[] = {
+		{ "gene_egg_model1.bmd",
+		  J3DMLF_MaterialPEFull | J3DMLF_UseUniqueMaterials
+		      | (1 << J3DMLF_TevStageNumShift),
+		  0 },
+		{ nullptr, 0, 0 },
+	};
+	createModelDataArray(entry);
+}
+
+void TEggGenManager::load(JSUMemoryInputStream& stream)
+{
+	unk38 = new TSpineEnemyParams("/enemy/egggen.prm");
+	TEnemyManager::load(stream);
+}

--- a/src/Enemy/egggen.cpp
+++ b/src/Enemy/egggen.cpp
@@ -7,6 +7,9 @@
 #include <Strategic/ObjModel.hpp>
 #include <dolphin/mtx.h>
 
+// rogue includes needed for matching sinit & bss
+#include <M3DUtil/InfectiousStrings.hpp>
+
 TEggGenerator::TEggGenerator(const char* name)
     : TSpineEnemy(name)
 {

--- a/src/Enemy/generator.cpp
+++ b/src/Enemy/generator.cpp
@@ -1,1 +1,143 @@
+#include <Enemy/Generator.hpp>
+#include <Enemy/Conductor.hpp>
+#include <Enemy/Enemy.hpp>
+#include <Enemy/EnemyManager.hpp>
+#include <Enemy/Graph.hpp>
+#include <JSystem/JDrama/JDRNameRefGen.hpp>
+#include <MarioUtil/MathUtil.hpp>
+#include <MarioUtil/RandomUtil.hpp>
+#include <Strategic/Strategy.hpp>
+#include <dolphin/mtx.h>
 
+TGenerator::TGenerator(const char* name)
+    : JDrama::TViewObj(name)
+{
+	mManagerName = nullptr;
+	mManager     = nullptr;
+	mGraphName   = nullptr;
+	mGraph       = nullptr;
+	mInterval    = 1;
+	mTimer       = 0;
+}
+
+void TGenerator::load(JSUMemoryInputStream& stream)
+{
+	// TODO: 89.9% - logic exact. Residual = the 3 discarded reads land in 3
+	// stack slots vs the target's 1 (stack-coalescing/frame-padding family).
+	JDrama::TNameRef::load(stream);
+
+	stream >> mPos.x >> mPos.y >> mPos.z;
+	stream >> mRot.x >> mRot.y >> mRot.z;
+
+	f32 unused;
+	stream >> unused;
+	stream >> unused;
+	stream >> unused;
+	stream.readString();
+
+	s32 count;
+	stream >> count;
+	for (int i = 0; i < count; ++i) {
+		s32 dummy;
+		stream >> dummy;
+		stream.readString();
+	}
+
+	mGraphName   = stream.readString();
+	mManagerName = stream.readString();
+
+	stream >> mInterval;
+	mTimer = (s32)(mInterval * MsRandF());
+
+	gpConductor->registerGenerator(this);
+}
+
+void TGenerator::perform(u32 flags, JDrama::TGraphics* graphics)
+{
+	if (flags & 1) {
+		mTimer -= 1;
+		if (mTimer < 0)
+			mTimer = mInterval;
+
+		if (mTimer == 0) {
+			if (mManager == nullptr)
+				mManager = (TEnemyManager*)gpConductor->getManagerByName(
+				    mManagerName);
+
+			TSpineEnemy* enemy = mManager->getFarOutEnemy();
+			if (enemy != nullptr) {
+				if (mGraph == nullptr)
+					mGraph = gpConductor->getGraphByName(mGraphName);
+
+				enemy->getTracer()->setGraph(mGraph);
+
+				JGeometry::TVec3<f32> rot(0.0f, 0.0f, 0.0f);
+				JGeometry::TVec3<f32> vel(0.0f, 4.0f, 0.0f);
+
+				Mtx m;
+				MsMtxSetRotRPH(m, mRot.x, mRot.y, mRot.z);
+				PSMTXMultVec(m, &vel, &vel);
+
+				enemy->resetSRTV(mPos, rot, enemy->mScaling, vel);
+			}
+		}
+	}
+}
+
+TOneShotGenerator::TOneShotGenerator(const char* name)
+    : THitActor(name)
+{
+	mManagerName = nullptr;
+	mManager     = nullptr;
+	mGraphName   = nullptr;
+	mGraph       = nullptr;
+	mCount       = 1;
+}
+
+void TOneShotGenerator::load(JSUMemoryInputStream& stream)
+{
+	JDrama::TActor::load(stream);
+	mGraphName   = stream.readString();
+	mManagerName = stream.readString();
+}
+
+void TOneShotGenerator::loadAfter()
+{
+	if (mCollisions == nullptr) {
+		mManager = (TEnemyManager*)gpConductor->getManagerByName(mManagerName);
+		if (mGraph == nullptr)
+			mGraph = gpConductor->getGraphByName(mGraphName);
+
+		initHitActor(0x02000001, 1, 0x80000000, 80.0f, 120.0f, 80.0f, 120.0f);
+		mHitFlags &= ~1;
+
+		JDrama::TNameRefGen::search<TIdxGroupObj>("敵グループ")
+		    ->getChildren()
+		    .push_back(this);
+		gpConductor->registerOtherObj(this);
+	}
+}
+
+BOOL TOneShotGenerator::receiveMessage(THitActor* sender, u32 message)
+{
+	if (sender->isActorType(0x01000001)) {
+		if (mCount != 0) {
+			TSpineEnemy* enemy = mManager->getFarOutEnemy();
+			if (enemy != nullptr) {
+				enemy->getTracer()->setGraph(mGraph);
+
+				JGeometry::TVec3<f32> rot(0.0f, 0.0f, 0.0f);
+				JGeometry::TVec3<f32> vel(0.0f, 4.0f, 0.0f);
+
+				Mtx m;
+				MsMtxSetRotRPH(m, mRotation.x, mRotation.y, mRotation.z);
+				PSMTXMultVec(m, &vel, &vel);
+
+				enemy->resetSRTV(mPosition, rot, enemy->mScaling, vel);
+			}
+			mCount = 0;
+		}
+		return TRUE;
+	}
+	return FALSE;
+}


### PR DESCRIPTION
Two small greenfield Enemy TUs, whole-class each. Build green (`mario.dol: OK`), clang-format 21 clean, no `volatile`/stack hacks.

### `Enemy/egggen.cpp` — `TEggGenerator` + `TEggGenManager`
- **100%:** both ctors/dtors (+`@32@` thunk), `TEggGenManager::load`, both vtables.
- `init` 99.9% / `control` 99.8% — byte-exact logic, residual is MWCC stack-padding.
- `createModelData` 99.2% — identical data, only the local `entry$` symbol number differs.
- `control` uses `!gpMarioOriginal->mYoshi->isHatched()`; models `gene_egg_model1.bmd`, params `/enemy/egggen.prm`.

### `Enemy/generator.cpp` — `TGenerator` + `TOneShotGenerator`
- **100%:** both ctors/dtors (+`@32@` thunk), `TOneShotGenerator::load`, both vtables.
- `loadAfter` 99.9% — registers into `敵グループ` via `TNameRefGen::search<TIdxGroupObj>(...)->getChildren().push_back(this)` + `TConductor::registerOtherObj`.
- `receiveMessage` 99.8% (`isActorType(0x01000001)` + `resetSRTV` spawn), `perform` 99.8% (timer-driven `getFarOutEnemy` spawn, velocity rotated by `MsMtxSetRotRPH`).
- `TGenerator::load` 89.9% — byte-exact logic; residual is the 3 discarded reads landing in 3 stack slots vs the target's 1 (stack-coalescing/frame-padding family). Left as `// TODO`.

All sub-100% functions are logic-complete with the residual noted; every diff is frame/scheduling, not wrong instructions.
