### PR TITLE
MoveBG/MapObjSirena (casino/Sirena map objects)

### DIFF
--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -1,0 +1,219 @@
+#ifndef MOVE_BG_MAP_OBJ_SIRENA_HPP
+#define MOVE_BG_MAP_OBJ_SIRENA_HPP
+
+#include <MarioUtil/ModelUtil.hpp>
+#include <MoveBG/MapObjBase.hpp>
+#include <MoveBG/MapObjHide.hpp>
+#include <Strategic/HitActor.hpp>
+
+// TODO: mark virtual methods as such
+
+// TODO: TMsRange<T> is only evidenced by two UNUSED dtor symbols in this TU
+// (__dt__11TMsRange<f>Fv / __dt__11TMsRange<l>Fv, 0x40 each). Its members and
+// whether the dtor is virtual are unknown - the shape below is a guess needed
+// so TItemSlotDrum's inlining is right. Needs human review.
+template <typename T> class TMsRange {
+public:
+	TMsRange() { }
+	~TMsRange() { }
+
+public:
+	/* 0x0 */ T mMin;
+	/* 0x4 */ T mMax;
+};
+
+class TPictureTelesa : public TWaterHitPictureHideObj {
+public:
+	TPictureTelesa(const char* name = "テルサの絵")
+	    : TWaterHitPictureHideObj(name)
+	{
+	}
+	void control();
+	void touchActor(THitActor*);
+	void afterFinishedAnim();
+};
+
+class TPanelRevolve : public TMapObjBase {
+public:
+	TPanelRevolve(const char* name = "回転棚")
+	    : TMapObjBase(name)
+	{
+	}
+	void control();
+	void touchPlayer(THitActor*);
+	BOOL receiveMessage(THitActor*, u32);
+};
+
+class TChestRevolve : public TMapObjBase {
+public:
+	TChestRevolve(const char* name = "回転棚")
+	    : TMapObjBase(name)
+	{
+	}
+	void control();
+	u32 touchWater(THitActor*);
+};
+
+class TWarpAreaActor : public THitActor {
+public:
+	TWarpAreaActor(const char* name = "ワープエリア");
+	void load(JSUMemoryInputStream&);
+	void perform(u32 cue, JDrama::TGraphics* graphics);
+
+public:
+	/* 0x68 */ s16 unk68;
+	/* 0x6A */ s16 unk6A;
+};
+
+class TSirenaCasinoRoof : public TMapObjBase {
+public:
+	TSirenaCasinoRoof(const char* name = "カジノ部屋天井")
+	    : TMapObjBase(name)
+	    , mMultiBtk(nullptr)
+	{
+	}
+	u32 getSDLModelFlag() const { return 0; }
+	void perform(u32 cue, JDrama::TGraphics* graphics);
+	void initMapObj();
+
+public:
+	/* 0x138 */ TMultiBtk* mMultiBtk;
+};
+
+class TSirenabossWall : public TMapObjBase {
+public:
+	TSirenabossWall(const char* name = "ボステレサ部屋壁")
+	    : TMapObjBase(name)
+	    , mMultiBtk(nullptr)
+	{
+	}
+	u32 getSDLModelFlag() const { return 0; }
+	void drawObject(JDrama::TGraphics*);
+	void perform(u32 cue, JDrama::TGraphics* graphics);
+	void initMapObj();
+
+public:
+	/* 0x138 */ TMultiBtk* mMultiBtk;
+};
+
+class TSakuCasino : public TMapObjBase {
+public:
+	TSakuCasino(const char* name = "パネル柵");
+	void calcRootMatrix();
+	void loadAfter();
+	void initMapObj();
+
+public:
+	/* 0x138 */ TMapCollisionWarp* unk138;
+	/* 0x13C */ u8 unk13C;
+	/* 0x140 */ f32 unk140;
+	/* 0x144 */ THitActor* unk144;
+};
+
+class TSirenaRollMapObj : public TMapObjBase {
+public:
+	TSirenaRollMapObj(const char* name = "SirenaRollMapObj");
+	virtual f32 getRollAngX(int) const { return 0.0f; }
+	virtual f32 getRollAngY(int) const { return 0.0f; }
+	virtual f32 getRollAngZ(int) const { return 0.0f; }
+
+public:
+	/* 0x138 */ f32* unk138;
+	/* 0x13C */ f32* unk13C;
+	/* 0x140 */ f32 unk140;
+	/* 0x144 */ f32 unk144;
+	/* 0x148 */ s32 unk148;
+	/* 0x14C */ f32 unk14C;
+	/* 0x150 */ f32 unk150;
+	/* 0x154 */ f32 unk154;
+	/* 0x158 */ f32 unk158;
+	/* 0x15C */ f32 unk15C;
+	/* 0x160 */ f32 unk160;
+	/* 0x164 */ u16 unk164;
+};
+
+class TCloset : public TSirenaRollMapObj {
+public:
+	TCloset(const char* name = "クローゼット");
+	u32 touchWater(THitActor*);
+	void calcRootMatrix();
+	void moveObject();
+	void initMapObj();
+	virtual f32 getRollAngY(int idx) const { return unk13C[idx]; }
+
+public:
+	/* 0x168 */ TMapCollisionWarp* mMapCollisionWarp;
+	/* 0x16C */ bool unk16C;
+	/* 0x16D */ u8 unk16D;
+};
+
+class TDonchou : public TMapObjBase {
+public:
+	TDonchou(const char* name = "パネルカーテン");
+	u32 touchWater(THitActor*);
+	void calcRootMatrix();
+	void loadAfter();
+	void initMapObj();
+};
+
+class TCasinoPanelGate : public TSirenaRollMapObj {
+public:
+	TCasinoPanelGate(const char* name = "カジノパネルゲート");
+	u32 touchWater(THitActor*);
+	void calcRootMatrix();
+	void moveObject();
+	void initMapObj();
+	virtual f32 getRollAngX(int idx) const { return unk13C[idx]; }
+};
+
+class TItemSlotDrum : public TSirenaRollMapObj {
+public:
+	TItemSlotDrum(const char* name = "スロットマシーン");
+	f32 getResultFromAng(f32);
+	int getForcastResult(int);
+	// UNUSED (MAP: size 0x50) - never called, but must exist for inlining
+	int getDrumResult(int);
+	// UNUSED (MAP: size 0x8C) - never called, but must exist for inlining
+	int getSlotResult();
+	void generateItem();
+	u32 touchWater(THitActor*);
+	void calcRootMatrix();
+	void moveObject();
+	void loadAfter();
+};
+
+class TSlotDrum : public TSirenaRollMapObj {
+public:
+	TSlotDrum(const char* name = "スロットマシーン");
+	u32 touchWater(THitActor*);
+	void calcRootMatrix();
+	void moveObject();
+	void initNeonMatColor();
+	void initMapObj();
+	virtual f32 getRollAngX(int idx) const { return unk13C[idx]; }
+};
+
+class TRoulette : public TMapObjBase {
+public:
+	TRoulette(const char* name = "ルーレット");
+	void switchStop();
+	void setRollSp(f32);
+	void calcRootMatrix();
+	void moveObject();
+	void perform(u32 cue, JDrama::TGraphics* graphics);
+	void initMapObj();
+};
+
+// TODO: TRouletteSw has a @32@ thunk for its dtor in the MAP, which means
+// multiple inheritance. The second base is not yet identified.
+class TRouletteSw : public TMapObjBase {
+public:
+	TRouletteSw(const char* name = "ルーレットスイッチ")
+	    : TMapObjBase(name)
+	{
+	}
+	void perform(u32 cue, JDrama::TGraphics* graphics);
+	BOOL receiveMessage(THitActor*, u32);
+};
+
+#endif

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -169,7 +169,7 @@ public:
 	/* 0x140 */ f32 unk140;
 	/* 0x144 */ TSlotDrum* unk144;
 	/* 0x148 */ TItemSlotDrum* unk148;
-	/* 0x14C */ u32 unk14C;
+	/* 0x14C */ s32 unk14C;
 };
 
 class TCasinoPanelGate : public TSirenaRollMapObj {

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -2,6 +2,7 @@
 #define MOVE_BG_MAP_OBJ_SIRENA_HPP
 
 #include <MarioUtil/ModelUtil.hpp>
+#include <MarioUtil/RandomUtil.hpp>
 #include <MoveBG/MapObjBase.hpp>
 #include <MoveBG/MapObjHide.hpp>
 #include <MoveBG/MapObjManager.hpp>
@@ -14,14 +15,20 @@ class TSlotDrum;
 class TItemSlotDrum;
 class TRouletteSw;
 
-// TODO: TMsRange<T> is only evidenced by two UNUSED dtor symbols in this TU
-// (__dt__11TMsRange<f>Fv / __dt__11TMsRange<l>Fv, 0x40 each). Its members and
-// whether the dtor is virtual are unknown - the shape below is a guess needed
-// so TItemSlotDrum's inlining is right. Needs human review.
+// A random-in-range helper. Only ever used fully inlined, so the only trace
+// left in the binary is the two UNUSED dtors for TMsRange<f32> / TMsRange<s32>.
 template <typename T> class TMsRange {
 public:
-	TMsRange() { }
-	~TMsRange() { }
+	TMsRange(T min, T max)
+	    : mMin(min)
+	    , mMax(max)
+	{
+	}
+	T rand() const
+	{
+		T range = mMax - mMin;
+		return mMin + (T)((f32)range * MsRandF());
+	}
 
 public:
 	/* 0x0 */ T mMin;

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -210,10 +210,18 @@ public:
 	TItemSlotDrum(const char* name = "スロットマシーン");
 	int getResultFromAng(f32);
 	int getForcastResult(int);
-	// UNUSED (MAP: size 0x50) - never called, but must exist for inlining
-	int getDrumResult(int);
-	// UNUSED (MAP: size 0x8C) - never called, but must exist for inlining
-	int getSlotResult();
+	// UNUSED as standalone symbols (MAP: 0x50 / 0x8C) - fully inlined into
+	// generateItem, so defined in-class.
+	int getDrumResult(int i) { return getResultFromAng(unk13C[i]); }
+	int getSlotResult()
+	{
+		int result = getDrumResult(0);
+		for (int i = 1; i < 3; i++) {
+			if (result != getDrumResult(i))
+				return -1;
+		}
+		return result;
+	}
 	void generateItem();
 	u32 touchWater(THitActor*);
 	void calcRootMatrix();

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -134,7 +134,7 @@ public:
 	/* 0x158 */ f32 unk158;
 	/* 0x15C */ f32 unk15C;
 	/* 0x160 */ f32 unk160;
-	/* 0x164 */ u16 unk164;
+	/* 0x164 */ s16 unk164;
 };
 
 class TCloset : public TSirenaRollMapObj {
@@ -206,9 +206,16 @@ public:
 	u32 touchWater(THitActor*);
 	void calcRootMatrix();
 	void moveObject();
-	void initNeonMatColor();
+	virtual void initNeonMatColor();
 	void initMapObj();
 	virtual f32 getRollAngX(int idx) const { return unk13C[idx]; }
+
+public:
+	/* 0x168 */ s32 unk168;
+	/* 0x16C */ u32 unk16C;
+	/* 0x170 */ GXColorS10 unk170[3];
+	/* 0x188 */ f32 unk188[3];
+	/* 0x194 */ u8 unk194;
 };
 
 class TRoulette : public TMapObjBase {

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -11,6 +11,7 @@
 class TCasinoPanelGate;
 class TSlotDrum;
 class TItemSlotDrum;
+class TRouletteSw;
 
 // TODO: TMsRange<T> is only evidenced by two UNUSED dtor symbols in this TU
 // (__dt__11TMsRange<f>Fv / __dt__11TMsRange<l>Fv, 0x40 each). Its members and
@@ -219,18 +220,33 @@ public:
 	void moveObject();
 	void perform(u32 cue, JDrama::TGraphics* graphics);
 	void initMapObj();
+
+public:
+	/* 0x138 */ f32 unk138;
+	/* 0x13C */ f32 unk13C;
+	/* 0x140 */ u8 unk140;
+	/* 0x141 */ u8 unk141;
+	/* 0x142 */ u8 unk142;
+	/* 0x144 */ f32 unk144;
+	/* 0x148 */ s16 unk148;
+	/* 0x14A */ s16 unk14A;
+	/* 0x14C */ s16 unk14C;
+	/* 0x14E */ s16 unk14E;
+	/* 0x150 */ TRouletteSw* unk150;
 };
 
-// TODO: TRouletteSw has a @32@ thunk for its dtor in the MAP, which means
-// multiple inheritance. The second base is not yet identified.
-class TRouletteSw : public TMapObjBase {
+class TRouletteSw : public THitActor {
 public:
 	TRouletteSw(const char* name = "ルーレットスイッチ")
-	    : TMapObjBase(name)
+	    : THitActor(name)
 	{
 	}
 	void perform(u32 cue, JDrama::TGraphics* graphics);
 	BOOL receiveMessage(THitActor*, u32);
+
+public:
+	/* 0x68 */ TRoulette* unk68;
+	/* 0x6C */ u8 unk6C;
 };
 
 #endif

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -184,22 +184,6 @@ public:
 	/* 0x16D */ u8 unk16D;
 };
 
-class TItemSlotDrum : public TSirenaRollMapObj {
-public:
-	TItemSlotDrum(const char* name = "スロットマシーン");
-	f32 getResultFromAng(f32);
-	int getForcastResult(int);
-	// UNUSED (MAP: size 0x50) - never called, but must exist for inlining
-	int getDrumResult(int);
-	// UNUSED (MAP: size 0x8C) - never called, but must exist for inlining
-	int getSlotResult();
-	void generateItem();
-	u32 touchWater(THitActor*);
-	void calcRootMatrix();
-	void moveObject();
-	void loadAfter();
-};
-
 class TSlotDrum : public TSirenaRollMapObj {
 public:
 	TSlotDrum(const char* name = "スロットマシーン");
@@ -216,6 +200,30 @@ public:
 	/* 0x170 */ GXColorS10 unk170[3];
 	/* 0x188 */ f32 unk188[3];
 	/* 0x194 */ u8 unk194;
+};
+
+class TItemSlotDrum : public TSlotDrum {
+public:
+	TItemSlotDrum(const char* name = "スロットマシーン");
+	int getResultFromAng(f32);
+	int getForcastResult(int);
+	// UNUSED (MAP: size 0x50) - never called, but must exist for inlining
+	int getDrumResult(int);
+	// UNUSED (MAP: size 0x8C) - never called, but must exist for inlining
+	int getSlotResult();
+	void generateItem();
+	u32 touchWater(THitActor*);
+	void calcRootMatrix();
+	void moveObject();
+	void loadAfter();
+
+public:
+	/* 0x198 */ u32 unk198;
+	/* 0x19C */ u8 unk19C[3];
+	/* 0x19F */ u8 unk19F[3];
+	/* 0x1A2 */ u8 unk1A2;
+	/* 0x1A4 */ u32 unk1A4;
+	/* 0x1A8 */ f32 unk1A8;
 };
 
 class TRoulette : public TMapObjBase {

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -36,6 +36,9 @@ public:
 	void control();
 	void touchActor(THitActor*);
 	void afterFinishedAnim();
+
+public:
+	/* 0x174 */ u8 unk174;
 };
 
 class TPanelRevolve : public TMapObjBase {

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -8,6 +8,8 @@
 
 // TODO: mark virtual methods as such
 
+class TCasinoPanelGate;
+
 // TODO: TMsRange<T> is only evidenced by two UNUSED dtor symbols in this TU
 // (__dt__11TMsRange<f>Fv / __dt__11TMsRange<l>Fv, 0x40 each). Its members and
 // whether the dtor is virtual are unknown - the shape below is a guess needed
@@ -107,7 +109,7 @@ public:
 	/* 0x138 */ TMapCollisionWarp* unk138;
 	/* 0x13C */ u8 unk13C;
 	/* 0x140 */ f32 unk140;
-	/* 0x144 */ THitActor* unk144;
+	/* 0x144 */ TCasinoPanelGate* unk144;
 };
 
 class TSirenaRollMapObj : public TMapObjBase {
@@ -164,6 +166,11 @@ public:
 	void moveObject();
 	void initMapObj();
 	virtual f32 getRollAngX(int idx) const { return unk13C[idx]; }
+
+public:
+	/* 0x168 */ TMapCollisionWarp* mMapCollisionWarp;
+	/* 0x16C */ bool unk16C;
+	/* 0x16D */ u8 unk16D;
 };
 
 class TItemSlotDrum : public TSirenaRollMapObj {

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -4,6 +4,7 @@
 #include <MarioUtil/ModelUtil.hpp>
 #include <MoveBG/MapObjBase.hpp>
 #include <MoveBG/MapObjHide.hpp>
+#include <MoveBG/MapObjManager.hpp>
 #include <Strategic/HitActor.hpp>
 
 // TODO: mark virtual methods as such

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -237,11 +237,11 @@ public:
 	void loadAfter();
 
 public:
-	/* 0x198 */ u32 unk198;
+	/* 0x198 */ s32 unk198;
 	/* 0x19C */ u8 unk19C[3];
 	/* 0x19F */ u8 unk19F[3];
 	/* 0x1A2 */ u8 unk1A2;
-	/* 0x1A4 */ u32 unk1A4;
+	/* 0x1A4 */ s32 unk1A4;
 	/* 0x1A8 */ f32 unk1A8;
 };
 

--- a/include/MoveBG/MapObjSirena.hpp
+++ b/include/MoveBG/MapObjSirena.hpp
@@ -9,6 +9,8 @@
 // TODO: mark virtual methods as such
 
 class TCasinoPanelGate;
+class TSlotDrum;
+class TItemSlotDrum;
 
 // TODO: TMsRange<T> is only evidenced by two UNUSED dtor symbols in this TU
 // (__dt__11TMsRange<f>Fv / __dt__11TMsRange<l>Fv, 0x40 each). Its members and
@@ -156,6 +158,14 @@ public:
 	void calcRootMatrix();
 	void loadAfter();
 	void initMapObj();
+
+public:
+	/* 0x138 */ TMapCollisionWarp* unk138;
+	/* 0x13C */ u8 unk13C;
+	/* 0x140 */ f32 unk140;
+	/* 0x144 */ TSlotDrum* unk144;
+	/* 0x148 */ TItemSlotDrum* unk148;
+	/* 0x14C */ u32 unk14C;
 };
 
 class TCasinoPanelGate : public TSirenaRollMapObj {

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -372,6 +372,87 @@ void TItemSlotDrum::calcRootMatrix()
 	model->setBaseScale(mScaling);
 }
 
+void TItemSlotDrum::moveObject()
+{
+	TLiveActor::moveObject();
+	mPosition.y = unk150 + unk14C;
+	if (unk1A4 > 0) {
+		unk1A4++;
+		if (unk1A4 > 160) {
+			unk1A4                             = 0;
+			unk19C[TMsRange<s32>(0, 2).rand()] = 1;
+			f32 v = TMsRange<f32>(0.0f, 100.0f).rand();
+			if (v < unk1A8 && unk1A8 > 10.0f)
+				unk198 = 0;
+			else if (v < 30.0f)
+				unk198 = 2;
+			else if (v < 60.0f)
+				unk198 = 3;
+			else
+				unk198 = 1;
+			unk1A8 += 2.0f;
+		}
+	}
+	for (int i = 0; i < unk148; i++) {
+		if (unk19C[i] != 0 && unk198 == getForcastResult(i)) {
+			unk19C[i] = 0;
+			unk19F[i] = 0;
+		}
+		if (unk138[i] != 0.0f) {
+			if (fabsf(unk138[i]) > unk160) {
+				unk13C[i] += unk138[i];
+				if (unk19F[i] == 0) {
+					if (unk138[i] > 0.0f)
+						unk138[i] -= unk15C;
+					else
+						unk138[i] += unk15C;
+				}
+				if (unk13C[i] >= 360.0f)
+					unk13C[i] -= 360.0f;
+				if (unk13C[i] <= 0.0f)
+					unk13C[i] += 360.0f;
+			} else {
+				unk13C[i] += unk138[i];
+				if (unk13C[i] >= 360.0f)
+					unk13C[i] -= 360.0f;
+				if (unk13C[i] <= 0.0f)
+					unk13C[i] += 360.0f;
+				if (unk19F[i] == 0 && (int)fabsf(unk13C[i]) % unk168 == 0) {
+					unk13C[i] = (f32)(unk168 * (int)(unk13C[i] / (f32)unk168));
+					unk138[i] = 0.0f;
+					gpMSound->startSoundActor(MSD_SE_BS_TELESA_SLT_STOP,
+					                          &mPosition, 0, nullptr, 0, 4);
+					bool allStopped = 0.0f == unk138[0] && 0.0f == unk138[1]
+					                  && 0.0f == unk138[2];
+					if (allStopped) {
+						unk1A2 = 1;
+						generateItem();
+					}
+					for (int j = 0; j < unk148; j++) {
+						if (unk19F[j] != 0) {
+							if (TMsRange<f32>(0.0f, 1.0f).rand() < 0.9f)
+								unk19C[j] = 1;
+							else
+								unk19F[j] = 0;
+						}
+					}
+					if (unk13C[i] < (f32)unk168) {
+						unk170[i].r = 255;
+						unk170[i].g = 255;
+						unk170[i].b = 70;
+						gpMSound->startSoundActor(MSD_SE_SY_COLLECT_DELIGHT,
+						                          &mPosition, 0, nullptr, 0, 4);
+					} else {
+						unk170[i].r = 120;
+						unk170[i].g = 230;
+						unk170[i].b = 255;
+					}
+				}
+			}
+		}
+	}
+}
+
 void TItemSlotDrum::loadAfter()
 {
 	TMapObjBase::loadAfter();

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -9,6 +9,8 @@
 #include <MarioUtil/MathUtil.hpp>
 #include <Strategic/ObjModel.hpp>
 #include <JSystem/JDrama/JDRNameRefGen.hpp>
+#include <JSystem/J3D/J3DGraphAnimator/J3DJoint.hpp>
+#include <JSystem/J3D/J3DGraphBase/J3DSys.hpp>
 #include <System/Application.hpp>
 #include <System/MarDirector.hpp>
 #include <math.h>
@@ -17,6 +19,40 @@
 // mario.MAP, because MoveBG is compiled with -inline deferred.
 
 static TSirenaRollMapObj* gpCurObject;
+
+static int partsRollCallback(J3DNode* node, int flag)
+{
+	if (flag == 0) {
+		if (gpCurObject == nullptr)
+			return 1;
+		int jntNo     = ((J3DJoint*)node)->getJntNo();
+		MtxPtr jntMtx = &gpCurObject->getModel()->getAnmMtx(jntNo)[0];
+		int idx       = jntNo - 1;
+		Mtx rot;
+		Mtx scale;
+		scale[0][3] = 0.0f;
+		scale[1][3] = 0.0f;
+		scale[2][3] = 0.0f;
+		scale[0][0] = gpCurObject->mScaling.x;
+		scale[0][1] = 0.0f;
+		scale[0][2] = 0.0f;
+		scale[1][0] = 0.0f;
+		scale[1][1] = gpCurObject->mScaling.y;
+		scale[1][2] = 0.0f;
+		scale[2][0] = 0.0f;
+		scale[2][1] = 0.0f;
+		scale[2][2] = gpCurObject->mScaling.z;
+		f32 rollZ = gpCurObject->getRollAngZ(idx);
+		f32 rollY = gpCurObject->getRollAngY(idx);
+		f32 rollX = gpCurObject->getRollAngX(idx);
+		MsMtxSetRotRPH(rot, rollX, rollY, rollZ);
+		PSMTXConcat(jntMtx, rot, jntMtx);
+		PSMTXConcat(jntMtx, scale, jntMtx);
+		PSMTXConcat(J3DSys::mCurrentMtx, rot, J3DSys::mCurrentMtx);
+		PSMTXConcat(J3DSys::mCurrentMtx, scale, J3DSys::mCurrentMtx);
+	}
+	return 1;
+}
 
 TSirenaRollMapObj::TSirenaRollMapObj(const char* name)
     : TMapObjBase(name)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -777,6 +777,20 @@ void TPictureTelesa::afterFinishedAnim()
 	}
 }
 
+void TPictureTelesa::touchActor(THitActor* actor)
+{
+	TWaterHitPictureHideObj::touchActor(actor);
+	if (isActorType(0x400001A2) && unk174 == 0 && isState(3)
+	    && !isStateTimerEngaged()) {
+		if (actor->mPosition.distance(mPosition) < 200.0f) {
+			startStateTimer(60);
+			gpMSound->startSoundActor(MSD_SE_BS_TELESA_DISAPPEAR, &mPosition, 0,
+			                          nullptr, 0, 4);
+			unk174 = 1;
+		}
+	}
+}
+
 void TPictureTelesa::control()
 {
 	TWaterHitPictureHideObj::control();

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -629,3 +629,20 @@ void TPanelRevolve::control()
 		break;
 	}
 }
+
+void TPictureTelesa::afterFinishedAnim()
+{
+	TWaterHitPictureHideObj::afterFinishedAnim();
+	if (isActorType(0x400001A2)) {
+		gpMSound->startSoundSystemSE(MSD_SE_SY_CLEAR_SIGN_BIG, 0, nullptr, 0);
+		gpMSound->startSoundActor(MSD_SE_BS_TELESA_V_LAUGH2, &mPosition, 0,
+		                          nullptr, 0, 4);
+	}
+}
+
+void TPictureTelesa::control()
+{
+	TWaterHitPictureHideObj::control();
+	if (unk174 != 0 && getColNum() == 0)
+		unk174 = 0;
+}

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -75,6 +75,31 @@ void TRoulette::calcRootMatrix()
 	model->setBaseScale(mScaling);
 }
 
+void TRoulette::switchStop()
+{
+	if (unk150->unk6C != 0) {
+		if (SMS_GetMarioPos().y < 20.0f + SMS_GetMarioGrLevel()
+		    && unk13C != 0.0f) {
+			unk150->unk6C = 0;
+			unk13C        = 0.0f;
+			unk148        = 0;
+			unk14A        = 0;
+			unk14C        = 0;
+			gpMSound->startSoundActor(MSD_SE_BS_TELESA_RLT_STOP, &mPosition, 0,
+			                          nullptr, 0, 4);
+		}
+		if (unk150->unk6C != 0 && unk141 != 0) {
+			unk150->unk6C = 0;
+			unk148        = 0;
+			unk14A        = 0;
+			unk14C        = 0;
+			gpMSound->startSoundActor(MSD_SE_BS_TELESA_RLT_STOP, &mPosition, 0,
+			                          nullptr, 0, 4);
+			unk140 = 1;
+		}
+	}
+}
+
 void TRoulette::setRollSp(f32 sp)
 {
 	unk13C          = sp;

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -1,1 +1,132 @@
+#include <MoveBG/MapObjSirena.hpp>
+#include <Enemy/Conductor.hpp>
+#include <Map/Map.hpp>
+#include <MSound/MSound.hpp>
+#include <MSound/SoundEffects.hpp>
+#include <Player/MarioAccess.hpp>
 
+// Definition order in this file is the REVERSE of the order symbols appear in
+// mario.MAP, because MoveBG is compiled with -inline deferred.
+
+static TSirenaRollMapObj* gpCurObject;
+
+TSirenaRollMapObj::TSirenaRollMapObj(const char* name)
+    : TMapObjBase(name)
+    , unk138(nullptr)
+    , unk13C(nullptr)
+    , unk148(0)
+    , unk14C(0.0f)
+    , unk150(0.0f)
+    , unk154(0.5f)
+    , unk158(10.0f)
+    , unk15C(0.1f)
+    , unk160(0.2f)
+    , unk164(1)
+{
+	gpCurObject = nullptr;
+}
+
+TCloset::TCloset(const char* name)
+    : TSirenaRollMapObj(name)
+    , mMapCollisionWarp(nullptr)
+    , unk16C(false)
+    , unk16D(0)
+{
+}
+
+void TWarpAreaActor::perform(u32 cue, JDrama::TGraphics* graphics)
+{
+	THitActor::perform(cue, graphics);
+	if (cue & CUE_MOVE) {
+		if (getColNum() != 0) {
+			if (*gpMarioSpeedY > 0.0f) {
+				if (unk68 != -1)
+					gpMap->changeModel(unk68);
+			}
+			if (*gpMarioSpeedY < 0.0f) {
+				if (unk6A != -1)
+					gpMap->changeModel(unk6A);
+			}
+		}
+	}
+}
+
+void TWarpAreaActor::load(JSUMemoryInputStream& stream)
+{
+	THitActor::load(stream);
+	u32 v;
+	stream.read(&v, 4);
+	unk68 = v;
+	stream.read(&v, 4);
+	unk6A = v;
+	initHitActor(0x4000019D, 1, -0x80000000, 100.0f * mScaling.x,
+	             100.0f * mScaling.y, 0.0f, 0.0f);
+	offHitFlag(HIT_FLAG_NO_COLLISION);
+	gpConductor->registerOtherObj(this);
+}
+
+TWarpAreaActor::TWarpAreaActor(const char* name)
+    : THitActor(name)
+    , unk68(-1)
+    , unk6A(-1)
+{
+}
+
+u32 TChestRevolve::touchWater(THitActor* actor)
+{
+	if (isState(1)) {
+		mState = 2;
+		startAnim(1);
+		setUpMapCollision(1);
+	}
+	return 1;
+}
+
+void TChestRevolve::control()
+{
+	TMapObjBase::control();
+	switch (mState) {
+	case 2:
+		if (animIsFinished()) {
+			mState = 1;
+			setUpMapCollision(0);
+		}
+		break;
+	}
+}
+
+BOOL TPanelRevolve::receiveMessage(THitActor* actor, u32 message)
+{
+	if (isState(1)) {
+		gpMSound->startSoundActor(MSD_SE_OBJ_PANEL_ROLL, &mPosition, 0,
+		                          nullptr, 0, 4);
+		mState = 2;
+		startAnim(1);
+		removeMapCollision();
+	}
+	return 1;
+}
+
+void TPanelRevolve::touchPlayer(THitActor* actor)
+{
+	if (marioHipAttack() && isState(1)) {
+		gpMSound->startSoundActor(MSD_SE_OBJ_PANEL_ROLL, &mPosition, 0,
+		                          nullptr, 0, 4);
+		mState = 2;
+		startAnim(1);
+		removeMapCollision();
+	}
+}
+
+void TPanelRevolve::control()
+{
+	TMapObjBase::control();
+	switch (mState) {
+	case 2:
+		if (animIsFinished()) {
+			mState = 1;
+			setUpCurrentMapCollision();
+		}
+		break;
+	}
+}

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -3,6 +3,8 @@
 #include <Map/Map.hpp>
 #include <MSound/MSound.hpp>
 #include <MSound/SoundEffects.hpp>
+#include <MSound/MSoundBGM.hpp>
+#include <MSound/BackgroundMusic.hpp>
 #include <Player/MarioAccess.hpp>
 #include <M3DUtil/MActorData.hpp>
 #include <Map/MapCollisionEntry.hpp>
@@ -236,6 +238,83 @@ void TSlotDrum::calcRootMatrix()
 	MsMtxSetXYZRPH(model->getBaseTRMtx(), mPosition.x, mPosition.y - unk14C,
 	               mPosition.z, mRotation.x, mRotation.y, mRotation.z);
 	model->setBaseScale(mScaling);
+}
+
+void TSlotDrum::moveObject()
+{
+	TLiveActor::moveObject();
+	mPosition.y = unk150 + unk14C;
+	for (int i = 0; i < unk148; i++) {
+		if (unk138[i] != 0.0f) {
+			unk188[i] += fabsf(unk138[i]);
+			if (unk188[i] > 360.0f / (f32)unk168) {
+				unk188[i] = 0.0f;
+				switch (i) {
+				case 0:
+					gpMSound->startSoundActor(MSD_SE_OBJ_SLOT_INC_L, &mPosition,
+					                          0, nullptr, 0, 4);
+					break;
+				case 1:
+					gpMSound->startSoundActor(MSD_SE_OBJ_SLOT_INC_C, &mPosition,
+					                          0, nullptr, 0, 4);
+					break;
+				case 2:
+					gpMSound->startSoundActor(MSD_SE_OBJ_SLOT_INC_R, &mPosition,
+					                          0, nullptr, 0, 4);
+					break;
+				}
+			}
+			if (fabsf(unk138[i]) > unk160) {
+				unk13C[i] += unk138[i];
+				if (unk138[i] > 0.0f)
+					unk138[i] -= unk15C;
+				else
+					unk138[i] += unk15C;
+				if (unk13C[i] >= 360.0f)
+					unk13C[i] -= 360.0f;
+				if (unk13C[i] <= 0.0f)
+					unk13C[i] += 360.0f;
+			} else {
+				unk13C[i] += unk138[i];
+				if (unk13C[i] >= 360.0f)
+					unk13C[i] -= 360.0f;
+				if (unk13C[i] <= 0.0f)
+					unk13C[i] += 360.0f;
+				if ((int)fabsf(unk13C[i]) % unk168 == 0) {
+					unk138[i] = 0.0f;
+					if (unk13C[i] < (f32)unk168) {
+						unk170[i].r = 255;
+						unk170[i].g = 255;
+						unk170[i].b = 70;
+						gpMSound->startSoundActor(MSD_SE_SY_COLLECT_DELIGHT,
+						                          &mPosition, 0, nullptr, 0, 4);
+					} else {
+						unk170[i].r = 120;
+						unk170[i].g = 230;
+						unk170[i].b = 255;
+					}
+					if (unk13C[i] < (f32)unk168 || unk13C[i] == 360.0f) {
+						bool allStopped = true;
+						for (int j = 0; j < unk148; j++) {
+							if (i == j)
+								continue;
+							if (unk138[j] != 0.0f)
+								return;
+							if (!(unk13C[j] < (f32)unk168
+							      || unk13C[j] >= 360.0f)) {
+								allStopped = false;
+								break;
+							}
+						}
+						if (allStopped) {
+							MSBgm::startBGM(MSD_BGM_FANFARE_RACE);
+							unk194 = 1;
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 u32 TSlotDrum::touchWater(THitActor* water)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -432,6 +432,37 @@ void TDonchou::initMapObj()
 	unk138->setUp();
 }
 
+void TDonchou::calcRootMatrix()
+{
+	J3DModel* model = getModel();
+	Mtx mtx;
+	MsMtxSetXYZRPH(mtx, mPosition.x, mPosition.y + unk140, mPosition.z,
+	               mRotation.x, mRotation.y, mRotation.z);
+	PSMTXCopy(mtx, model->getBaseTRMtx());
+	model->setBaseScale(mScaling);
+	mtx[1][3] += unk140;
+	if (unk144 != nullptr && unk144->unk194 != 0 && unk148->unk194 != 0)
+		unk13C = 1;
+	if (unk13C != 0) {
+		unk14C++;
+		if (unk14C > 100) {
+			if (mMActor->checkCurAnm("donchou", 0)) {
+				if (mMActor->curAnmEndsNext(0, 0))
+					unk138->remove();
+			} else {
+				gpMSound->startSoundActor(MSD_SE_SY_DONCHO_OPEN, &mPosition, 0,
+				                          nullptr, 0, 4);
+				mMActor->setBck("donchou");
+				gpMarDirector->fireStartDemoCamera("どんちょカメラ", &mPosition,
+				                                   -1, 0.0f, true, nullptr, 0,
+				                                   nullptr, JDrama::TFlagT<u16>(0));
+				J3DFrameCtrl* fc = mMActor->getFrameCtrl(0);
+				fc->setRate(0.5f * fc->getRate());
+			}
+		}
+	}
+}
+
 void TDonchou::loadAfter()
 {
 	TMapObjBase::loadAfter();

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -15,6 +15,8 @@
 #include <JSystem/J3D/J3DGraphBase/J3DSys.hpp>
 #include <System/Application.hpp>
 #include <System/MarDirector.hpp>
+#include <System/MarioGamePad.hpp>
+#include <Player/Mario.hpp>
 #include <math.h>
 
 // Definition order in this file is the REVERSE of the order symbols appear in
@@ -58,6 +60,24 @@ TRoulette::TRoulette(const char* name)
 	if (gpApplication.mCurrArea.unk0 == 56) {
 		unk14C = 255;
 		unk142 = 1;
+	}
+}
+
+void TRoulette::moveObject()
+{
+	TLiveActor::moveObject();
+	if (unk142 != 0) {
+		mRotation.x += unk13C;
+		if (unk141 != 0 && unk140 != 0) {
+			gpMarioOriginal->mGamePad->onNeutralMarioKey();
+			gpMarioOriginal->mGamePad->mDisabledFrames = 5;
+			gpMSound->startSoundActor(MSD_SE_BS_TELESA_RLT_DOWN, &mPosition, 0,
+			                          nullptr, 0, 4);
+			mPosition.y -= 0.5f;
+			MtxPtr jnt                   = mMActor->getModel()->getAnmMtx(1);
+			JGeometry::TVec3<f32>& swPos = unk150->mPosition;
+			swPos.set(jnt[0][3], mPosition.y - 100.0f, jnt[2][3]);
+		}
 	}
 }
 

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -174,6 +174,106 @@ u32 TSlotDrum::touchWater(THitActor* water)
 	return 0;
 }
 
+TCasinoPanelGate::TCasinoPanelGate(const char* name)
+    : TSirenaRollMapObj(name)
+    , mMapCollisionWarp(nullptr)
+    , unk16C(false)
+    , unk16D(0)
+{
+}
+
+void TCasinoPanelGate::initMapObj()
+{
+	unk148 = 16;
+	unk14C = 410.0f;
+	unk150 = mPosition.y;
+	unk154 = 4.0f;
+	unk158 = 15.0f;
+	unk15C = 0.2f;
+	unk160 = 0.5f;
+	unk164 = 0;
+	unk138 = new f32[unk148];
+	unk13C = new f32[unk148];
+	for (int i = 0; i < unk148; i++) {
+		unk138[i] = 0.0f;
+		unk13C[i] = 0.0f;
+	}
+	TMapObjBase::initMapObj();
+	for (u16 i = 1; i <= unk148; i++)
+		mMActor->setJointCallback(i, partsRollCallback);
+}
+
+void TCasinoPanelGate::calcRootMatrix()
+{
+	gpCurObject     = this;
+	J3DModel* model = getModel();
+	MsMtxSetXYZRPH(model->getBaseTRMtx(), mPosition.x, mPosition.y + unk14C,
+	               mPosition.z, mRotation.x, mRotation.y, mRotation.z);
+	model->setBaseScale(mScaling);
+	unk140 = 0.25f * mDamageRadius;
+	unk144 = 0.25f * mDamageHeight;
+}
+
+u32 TCasinoPanelGate::touchWater(THitActor* water)
+{
+	if (unk16D != 0)
+		return 1;
+	if (fabsf(mPosition.z - water->mPosition.z) < 50.0f) {
+		unk164 = 1;
+		int idx;
+		if (water->mPosition.y > 3.0f * unk144 + mPosition.y) {
+			if (water->mPosition.x < mPosition.x - unk140)
+				idx = 12;
+			else if (water->mPosition.x < mPosition.x)
+				idx = 13;
+			else if (water->mPosition.x > mPosition.x + unk140)
+				idx = 15;
+			else
+				idx = 14;
+			if (water->mPosition.y < 3.5f * unk144 + mPosition.y)
+				unk164 = -1;
+		} else if (water->mPosition.y > 2.0f * unk144 + mPosition.y) {
+			if (water->mPosition.x < mPosition.x - unk140)
+				idx = 8;
+			else if (water->mPosition.x < mPosition.x)
+				idx = 9;
+			else if (water->mPosition.x > mPosition.x + unk140)
+				idx = 11;
+			else
+				idx = 10;
+			if (water->mPosition.y < 2.5f * unk144 + mPosition.y)
+				unk164 = -1;
+		} else if (water->mPosition.y > mPosition.y + unk144) {
+			if (water->mPosition.x < mPosition.x - unk140)
+				idx = 4;
+			else if (water->mPosition.x < mPosition.x)
+				idx = 5;
+			else if (water->mPosition.x > mPosition.x + unk140)
+				idx = 7;
+			else
+				idx = 6;
+			if (water->mPosition.y < 1.5f * unk144 + mPosition.y)
+				unk164 = -1;
+		} else {
+			if (water->mPosition.x < mPosition.x - unk140)
+				idx = 0;
+			else if (water->mPosition.x < mPosition.x)
+				idx = 1;
+			else if (water->mPosition.x > mPosition.x + unk140)
+				idx = 3;
+			else
+				idx = 2;
+			if (water->mPosition.y < 0.5f * unk144 + mPosition.y)
+				unk164 = -1;
+		}
+		unk138[idx] += unk154 * unk164;
+		if (fabsf(unk138[idx]) > unk158)
+			unk138[idx] = unk158 * unk164;
+		return 1;
+	}
+	return 0;
+}
+
 TDonchou::TDonchou(const char* name)
     : TMapObjBase(name)
     , unk138(nullptr)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -174,6 +174,47 @@ u32 TSlotDrum::touchWater(THitActor* water)
 	return 0;
 }
 
+TItemSlotDrum::TItemSlotDrum(const char* name)
+    : TSlotDrum(name)
+    , unk198(0)
+    , unk1A4(0)
+    , unk1A8(5.0f)
+{
+	for (int i = 0; i < 3; i++) {
+		unk19C[i] = 0;
+		unk19F[i] = 1;
+	}
+	unk1A2 = 1;
+}
+
+void TItemSlotDrum::calcRootMatrix()
+{
+	gpCurObject = this;
+	u8 spinning = 0;
+	for (int i = 0; i < 3; i++) {
+		if (0.0f != unk138[i])
+			spinning = 1;
+	}
+	if (spinning)
+		gpMSound->startSoundActor(MSD_SE_OBJ_SLOT_SPIN, &mPosition, 0, nullptr,
+		                          0, 4);
+	J3DModel* model = getModel();
+	MsMtxSetXYZRPH(model->getBaseTRMtx(), mPosition.x, mPosition.y - unk14C,
+	               mPosition.z, mRotation.x, mRotation.y, mRotation.z);
+	model->setBaseScale(mScaling);
+}
+
+int TItemSlotDrum::getResultFromAng(f32 ang)
+{
+	if (ang < 89.0f)
+		return 0;
+	if (ang < 179.0f)
+		return 1;
+	if (ang < 269.0f)
+		return 2;
+	return 3;
+}
+
 TCasinoPanelGate::TCasinoPanelGate(const char* name)
     : TSirenaRollMapObj(name)
     , mMapCollisionWarp(nullptr)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -132,6 +132,48 @@ TSirenaRollMapObj::TSirenaRollMapObj(const char* name)
 	gpCurObject = nullptr;
 }
 
+TSlotDrum::TSlotDrum(const char* name)
+    : TSirenaRollMapObj(name)
+    , unk194(0)
+{
+}
+
+void TSlotDrum::calcRootMatrix()
+{
+	gpCurObject     = this;
+	J3DModel* model = getModel();
+	MsMtxSetXYZRPH(model->getBaseTRMtx(), mPosition.x, mPosition.y - unk14C,
+	               mPosition.z, mRotation.x, mRotation.y, mRotation.z);
+	model->setBaseScale(mScaling);
+}
+
+u32 TSlotDrum::touchWater(THitActor* water)
+{
+	if (unk194 != 0)
+		return 1;
+	if (fabsf(mPosition.x - water->mPosition.x) < 150.0f) {
+		f32 halfDepth = 0.6f * unk140;
+		int idx;
+		if (water->mPosition.z < mPosition.z - halfDepth) {
+			idx = 2;
+			if (mRotation.y < 0.0f)
+				idx = 0;
+		} else if (water->mPosition.z > mPosition.z + halfDepth) {
+			idx = 0;
+			if (mRotation.y < 0.0f)
+				idx = 2;
+		} else {
+			idx = 1;
+		}
+		unk164 = 1;
+		unk138[idx] += unk154 * unk164;
+		if (fabsf(unk138[idx]) > unk158)
+			unk138[idx] = unk158 * unk164;
+		return 1;
+	}
+	return 0;
+}
+
 TDonchou::TDonchou(const char* name)
     : TMapObjBase(name)
     , unk138(nullptr)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -120,6 +120,40 @@ TCloset::TCloset(const char* name)
 {
 }
 
+void TCloset::initMapObj()
+{
+	unk148 = 4;
+	unk14C = 0.0f;
+	unk150 = mPosition.y;
+	unk154 = 2.5f;
+	unk158 = 8.0f;
+	unk15C = 0.1f;
+	unk160 = 0.5f;
+	unk164 = 0;
+	unk16C = false;
+	unk16D = 0;
+	unk138 = new f32[unk148];
+	unk13C = new f32[unk148];
+	for (int i = 0; i < unk148; i++) {
+		unk138[i] = 0.0f;
+		unk13C[i] = 180.0f;
+	}
+	TMapObjBase::initMapObj();
+	for (int i = 1; i <= unk148; i++)
+		mMActor->setJointCallback(i, partsRollCallback);
+	unk140 = 0.25f * mDamageRadius;
+	unk144 = mDamageHeight;
+	getModel();
+	Mtx mtx;
+	MsMtxSetXYZRPH(mtx, mPosition.x, 2.0f * unk14C + mPosition.y, mPosition.z,
+	               mRotation.x, mRotation.y, mRotation.z);
+	mMapCollisionWarp = new TMapCollisionWarp();
+	mMapCollisionWarp->init("/mapObj/Closet", 0, this);
+	PSMTXCopy(mtx, mMapCollisionWarp->unk20);
+	mMapCollisionWarp->setUp();
+	initAnmSound();
+}
+
 TSakuCasino::TSakuCasino(const char* name)
     : TMapObjBase(name)
     , unk138(nullptr)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -4,6 +4,8 @@
 #include <MSound/MSound.hpp>
 #include <MSound/SoundEffects.hpp>
 #include <Player/MarioAccess.hpp>
+#include <M3DUtil/MActorData.hpp>
+#include <Strategic/ObjModel.hpp>
 
 // Definition order in this file is the REVERSE of the order symbols appear in
 // mario.MAP, because MoveBG is compiled with -inline deferred.
@@ -32,6 +34,58 @@ TCloset::TCloset(const char* name)
     , unk16C(false)
     , unk16D(0)
 {
+}
+
+void TSirenabossWall::initMapObj()
+{
+	TMapObjBase::initMapObj();
+	mMActor->offMakeDL();
+	MActorAnmData* anmData = mMActorKeeper->getMActorAnmData();
+	mMultiBtk               = new TMultiBtk(3, getModel()->getModelData());
+	for (int i = 0; i <= 2; i++) {
+		J3DAnmTextureSRTKey* data;
+		if (i < anmData->getUnk38()->getAnmNum())
+			data = (J3DAnmTextureSRTKey*)anmData->getUnk38()->unkC[i];
+		else
+			data = nullptr;
+		mMultiBtk->setNthData(i, data);
+	}
+}
+
+void TSirenabossWall::perform(u32 cue, JDrama::TGraphics* graphics)
+{
+	if (cue & CUE_CALC_ANIM)
+		mMultiBtk->update();
+	TMapObjBase::perform(cue, graphics);
+}
+
+void TSirenabossWall::drawObject(JDrama::TGraphics* graphics)
+{
+	mMActor->getModel()->calc();
+}
+
+void TSirenaCasinoRoof::initMapObj()
+{
+	TMapObjBase::initMapObj();
+	mMActor->offMakeDL();
+	MActorAnmData* anmData = mMActorKeeper->getMActorAnmData();
+	mMultiBtk               = new TMultiBtk(3, getModel()->getModelData());
+	for (int i = 0; i <= 2; i++) {
+		J3DAnmTextureSRTKey* data;
+		if (i < anmData->getUnk38()->getAnmNum())
+			data = (J3DAnmTextureSRTKey*)anmData->getUnk38()->unkC[i];
+		else
+			data = nullptr;
+		mMultiBtk->setNthData(i, data);
+	}
+	mMActor->setBrk("casino_lighting");
+}
+
+void TSirenaCasinoRoof::perform(u32 cue, JDrama::TGraphics* graphics)
+{
+	if (cue & CUE_CALC_ANIM)
+		mMultiBtk->update();
+	TMapObjBase::perform(cue, graphics);
 }
 
 void TWarpAreaActor::perform(u32 cue, JDrama::TGraphics* graphics)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -294,22 +294,17 @@ void TSlotDrum::moveObject()
 						unk170[i].b = 255;
 					}
 					if (unk13C[i] < (f32)unk168 || unk13C[i] == 360.0f) {
-						bool allStopped = true;
 						for (int j = 0; j < unk148; j++) {
 							if (i == j)
 								continue;
 							if (unk138[j] != 0.0f)
 								return;
 							if (!(unk13C[j] < (f32)unk168
-							      || unk13C[j] >= 360.0f)) {
-								allStopped = false;
-								break;
-							}
+							      || unk13C[j] >= 360.0f))
+								return;
 						}
-						if (allStopped) {
-							MSBgm::startBGM(MSD_BGM_FANFARE_RACE);
-							unk194 = 1;
-						}
+						MSBgm::startBGM(MSD_BGM_FANFARE_RACE);
+						unk194 = 1;
 					}
 				}
 			}
@@ -598,6 +593,75 @@ void TCloset::initMapObj()
 	PSMTXCopy(mtx, mMapCollisionWarp->unk20);
 	mMapCollisionWarp->setUp();
 	initAnmSound();
+}
+
+void TCloset::moveObject()
+{
+	TLiveActor::moveObject();
+	if (unk16C != 0 && !mMActor->checkCurAnm("closetopen", 0)) {
+		unk16D++;
+		if (unk16D == 60) {
+			mMActor->setBck("closetopen");
+			setAnmSound("/scene/mapObj/closetopen.bas");
+		}
+	} else {
+		for (int i = 0; i < unk148; i++) {
+			if (unk138[i] != 0.0f) {
+				if (fabsf(unk138[i]) > unk160) {
+					unk13C[i] += unk138[i];
+					if (unk138[i] > 0.0f)
+						unk138[i] -= unk15C;
+					else
+						unk138[i] += unk15C;
+					bool wrapped = false;
+					if (unk13C[i] >= 360.0f) {
+						unk13C[i] -= 360.0f;
+						wrapped = true;
+					}
+					if (unk13C[i] <= 0.0f) {
+						unk13C[i] += 360.0f;
+						wrapped = true;
+					}
+					if (wrapped)
+						gpMSound->startSoundActorWithInfo(
+						    MSD_SE_OBJ_TEL_CLOSET_ROLL, &mPosition, nullptr,
+						    fabsf(unk138[i]), 0, 0, nullptr, 0, 4);
+				} else {
+					unk13C[i] += unk138[i];
+					bool wrapped = false;
+					if (unk13C[i] >= 360.0f) {
+						unk13C[i] -= 360.0f;
+						wrapped = true;
+					}
+					if (unk13C[i] <= 0.0f) {
+						unk13C[i] += 360.0f;
+						wrapped = true;
+					}
+					if (wrapped)
+						gpMSound->startSoundActorWithInfo(
+						    MSD_SE_OBJ_TEL_CLOSET_ROLL, &mPosition, nullptr,
+						    fabsf(unk138[i]), 0, 0, nullptr, 0, 4);
+					if ((int)fabsf(unk13C[i]) % 180 == 0) {
+						unk138[i] = 0.0f;
+						if (unk13C[i] < 180.0f || unk13C[i] == 360.0f) {
+							for (int j = 0; j < unk148; j++) {
+								if (i == j)
+									continue;
+								if (unk138[j] != 0.0f)
+									return;
+								if (!(unk13C[j] < 180.0f
+								      || unk13C[j] >= 360.0f))
+									return;
+							}
+							unk16C = 1;
+							gpMSound->startSoundSystemSE(MSD_SE_SY_CLEAR_SIGN_BIG,
+							                             0, nullptr, 0);
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 void TCloset::calcRootMatrix()

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -21,6 +21,7 @@
 #include <System/MarioGamePad.hpp>
 #include <Player/Mario.hpp>
 #include <math.h>
+#include <stdlib.h>
 
 // Definition order in this file is the REVERSE of the order symbols appear in
 // mario.MAP, because MoveBG is compiled with -inline deferred.
@@ -368,6 +369,30 @@ void TItemSlotDrum::calcRootMatrix()
 	MsMtxSetXYZRPH(model->getBaseTRMtx(), mPosition.x, mPosition.y - unk14C,
 	               mPosition.z, mRotation.x, mRotation.y, mRotation.z);
 	model->setBaseScale(mScaling);
+}
+
+u32 TItemSlotDrum::touchWater(THitActor* water)
+{
+	if (unk194 != 0)
+		return 1;
+	if (unk1A2 != 0) {
+		// TODO: ~55%. The target keeps lo/hi as int stack locals and computes
+		// hi - lo at runtime (rather than folding to 50), which looks like an
+		// inlined random-in-range helper that isn't identified yet.
+		int lo   = 100;
+		int hi   = 150;
+		unk1A4   = lo + (int)((f32)(hi - lo) * ((f32)rand() * (1.0f / 32768.0f)));
+		for (int i = 0; i < unk148; i++) {
+			unk19F[i] = 1;
+			unk19C[i] = 0;
+			f32 spLo  = 0.5f;
+			f32 spHi  = 0.8f;
+			unk138[i] = unk158
+			          * (spLo + (spHi - spLo) * ((f32)rand() * (1.0f / 32768.0f)));
+		}
+		unk1A2 = 0;
+	}
+	return 1;
 }
 
 int TItemSlotDrum::getResultFromAng(f32 ang)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -1,5 +1,9 @@
 #include <MoveBG/MapObjSirena.hpp>
 #include <Enemy/Conductor.hpp>
+#include <Enemy/Telesa.hpp>
+#include <MoveBG/ItemManager.hpp>
+#include <JSystem/JMath.hpp>
+#include <dolphin/mtx.h>
 #include <Map/Map.hpp>
 #include <MSound/MSound.hpp>
 #include <MSound/SoundEffects.hpp>
@@ -478,6 +482,89 @@ u32 TItemSlotDrum::touchWater(THitActor* water)
 		unk1A2 = 0;
 	}
 	return 1;
+}
+
+void TItemSlotDrum::generateItem()
+{
+	if (getSlotResult() == 0) {
+		MSBgm::startBGM(MSD_BGM_FANFARE_RACE);
+		unk194 = 1;
+		return;
+	}
+	if (getSlotResult() == 1) {
+		TTelesa* item = (TTelesa*)gpConductor->makeOneEnemyAppear(
+		    getPosition(), "テレサマネージャー", 1);
+		if (item != nullptr) {
+			s16 ang = (s16)DEG2SHORTANGLE(mRotation.x);
+			f32 s   = JMASSin(ang);
+			f32 c   = JMASCos(ang);
+			Mtx m;
+			m[0][0] = c;
+			m[0][1] = 0.0f;
+			m[0][2] = s;
+			m[0][3] = 0.0f;
+			m[1][0] = 0.0f;
+			m[1][1] = 1.0f;
+			m[1][2] = 0.0f;
+			m[1][3] = 0.0f;
+			m[2][0] = -s;
+			m[2][1] = 0.0f;
+			m[2][2] = c;
+			m[2][3] = 0.0f;
+			JGeometry::TVec3<f32> off(0.0f, -350.0f, 300.0f);
+			PSMTXMultVec(m, &off, &off);
+			item->mPosition.x += off.x;
+			item->mPosition.y += off.y;
+			item->mPosition.z += off.z;
+			item->initItemAttacker(this);
+		}
+		return;
+	}
+	if (getSlotResult() != -1) {
+		int count  = 1;
+		f32 spread = 0.0f;
+		if (getSlotResult() == 2) {
+			count  = 3;
+			spread = 20.0f;
+		}
+		for (int i = 0; i < count; i++) {
+			s16 ang = (s16)DEG2SHORTANGLE(spread * ((f32)i - 1.0f)
+			                              + (mRotation.x - spread));
+			f32 s   = JMASSin(ang);
+			f32 c   = JMASCos(ang);
+			Mtx m;
+			m[0][0] = c;
+			m[0][1] = 0.0f;
+			m[0][2] = s;
+			m[0][3] = 0.0f;
+			m[1][0] = 0.0f;
+			m[1][1] = 1.0f;
+			m[1][2] = 0.0f;
+			m[1][3] = 0.0f;
+			m[2][0] = -s;
+			m[2][1] = 0.0f;
+			m[2][2] = c;
+			m[2][3] = 0.0f;
+			JGeometry::TVec3<f32> off(0.0f, -350.0f, 200.0f);
+			PSMTXMultVec(m, &off, &off);
+			TMapObjBase* item = gpItemManager->makeObjAppear(
+			    mPosition.x + off.x, mPosition.y, mPosition.z + off.z,
+			    0x2000000E, false);
+			if (item != nullptr) {
+				item->mPosition.x += off.x;
+				item->mPosition.y += off.y;
+				item->mPosition.z += off.z;
+				MsVECNormalize(&off, &off);
+				item->mVelocity.x = 12.0f * off.x;
+				item->mVelocity.y = TMsRange<f32>(5.0f, 10.0f).rand();
+				item->mVelocity.z = 12.0f * off.z;
+				item->offLiveFlag(0x10);
+			}
+		}
+	} else {
+		gpMSound->startSoundActor(MSD_SE_SY_NOT_COLLECT, &mPosition, 0, nullptr,
+		                          0, 4);
+	}
 }
 
 int TItemSlotDrum::getForcastResult(int idx)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -258,6 +258,39 @@ void TCloset::initMapObj()
 	initAnmSound();
 }
 
+u32 TCloset::touchWater(THitActor* water)
+{
+	if (unk16C != 0)
+		return 0;
+	if (fabsf(mPosition.x - water->mPosition.x) < 50.0f) {
+		f32 halfDepth = 1.1f * unk140;
+		int idx;
+		if (water->mPosition.z < mPosition.z - halfDepth) {
+			idx = 0;
+			if (mRotation.y < 0.0f)
+				idx = 3;
+		} else if (water->mPosition.z < mPosition.z) {
+			idx = 1;
+			if (mRotation.y < 0.0f)
+				idx = 2;
+		} else if (water->mPosition.z < mPosition.z + halfDepth) {
+			idx = 2;
+			if (mRotation.y < 0.0f)
+				idx = 1;
+		} else {
+			idx = 3;
+			if (mRotation.y < 0.0f)
+				idx = 0;
+		}
+		unk164 = 1;
+		unk138[idx] += unk154 * unk164;
+		if (fabsf(unk138[idx]) > unk158)
+			unk138[idx] = unk158 * unk164;
+		return 1;
+	}
+	return 0;
+}
+
 TSakuCasino::TSakuCasino(const char* name)
     : TMapObjBase(name)
     , unk138(nullptr)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -15,6 +15,7 @@
 #include <JSystem/JDrama/JDRNameRefGen.hpp>
 #include <JSystem/J3D/J3DGraphAnimator/J3DJoint.hpp>
 #include <JSystem/J3D/J3DGraphBase/J3DSys.hpp>
+#include <JSystem/J3D/J3DGraphAnimator/J3DAnimation.hpp>
 #include <System/Application.hpp>
 #include <System/MarDirector.hpp>
 #include <System/MarioGamePad.hpp>
@@ -407,6 +408,84 @@ void TCasinoPanelGate::initMapObj()
 	TMapObjBase::initMapObj();
 	for (u16 i = 1; i <= unk148; i++)
 		mMActor->setJointCallback(i, partsRollCallback);
+}
+
+void TCasinoPanelGate::moveObject()
+{
+	TLiveActor::moveObject();
+	mPosition.y = unk150 - unk14C;
+	if (unk16D != 0) {
+		J3DFrameCtrl* fc = mMActor->getFrameCtrl(0);
+		if (fc->getFrame() >= (f32)fc->getEnd() - 8.0f) {
+			gpMSound->startSoundSystemSE(MSD_SE_SY_PANELPUZZLE_OPEN, 0, nullptr,
+			                             0);
+			if (unk16C == 0 && fc->checkPass((f32)fc->getEnd() - 2.0f)) {
+				unk16C = 1;
+				gpMSound->startSoundSystemSE(MSD_SE_SY_CLEAR_SIGN_BIG, 0,
+				                             nullptr, 0);
+			}
+		}
+	} else {
+		bool allOpen = true;
+		for (int i = 0; i < unk148; i++) {
+			if (unk138[i] == 0.0f) {
+				if (unk13C[i] < 180.0f)
+					allOpen = false;
+			} else {
+				allOpen = false;
+				if (fabsf(unk138[i]) > unk160) {
+					unk13C[i] += unk138[i];
+					if (unk138[i] > 0.0f)
+						unk138[i] -= unk15C;
+					else
+						unk138[i] += unk15C;
+					bool wrapped = false;
+					if (unk13C[i] >= 360.0f) {
+						unk13C[i] -= 360.0f;
+						wrapped = true;
+					}
+					if (unk13C[i] <= 0.0f) {
+						unk13C[i] += 360.0f;
+						wrapped = true;
+					}
+					if (wrapped)
+						gpMSound->startSoundActorWithInfo(
+						    MSD_SE_OBJ_PANELPUZZLE_WIND, &mPosition, nullptr,
+						    fabsf(unk138[i]), 0, 0, nullptr, 0, 4);
+				} else {
+					unk13C[i] += unk138[i];
+					bool wrapped = false;
+					if (unk13C[i] >= 360.0f) {
+						unk13C[i] -= 360.0f;
+						wrapped = true;
+					}
+					if (unk13C[i] <= 0.0f) {
+						unk13C[i] += 360.0f;
+						wrapped = true;
+					}
+					if (wrapped)
+						gpMSound->startSoundActorWithInfo(
+						    MSD_SE_OBJ_PANELPUZZLE_WIND, &mPosition, nullptr,
+						    fabsf(unk138[i]), 0, 0, nullptr, 0, 4);
+					if ((int)fabsf(unk13C[i]) % 180 == 0) {
+						if (unk13C[i] < 180.0f)
+							unk13C[i] = 180.0f;
+						else if (unk13C[i] < 360.0f)
+							unk13C[i] = 0.0f;
+						unk138[i] = 0.0f;
+					}
+				}
+			}
+		}
+		if (allOpen) {
+			unk16D = 1;
+			mMActor->setBck("pazul");
+			MSBgm::startBGM(MSD_BGM_FANFARE_RACE);
+			gpMSound->startSoundActor(MSD_SE_SY_COLLECT_DELIGHT, &mPosition, 0,
+			                          nullptr, 0, 4);
+			removeMapCollision();
+		}
+	}
 }
 
 void TCasinoPanelGate::calcRootMatrix()

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -395,6 +395,34 @@ u32 TItemSlotDrum::touchWater(THitActor* water)
 	return 1;
 }
 
+int TItemSlotDrum::getForcastResult(int idx)
+{
+	f32 angle = unk13C[idx];
+	f32 speed = unk138[idx];
+	for (;;) {
+		if (fabsf(speed) > unk160) {
+			angle += speed;
+			if (speed > 0.0f)
+				speed -= unk15C;
+			else
+				speed += unk15C;
+			if (angle >= 360.0f)
+				angle -= 360.0f;
+			if (angle <= 0.0f)
+				angle += 360.0f;
+		} else {
+			angle += speed;
+			if (angle >= 360.0f)
+				angle -= 360.0f;
+			if (angle <= 0.0f)
+				angle += 360.0f;
+			if ((int)fabsf(angle) % unk168 == 0)
+				break;
+		}
+	}
+	return getResultFromAng((f32)(unk168 * (int)(angle / (f32)unk168)));
+}
+
 int TItemSlotDrum::getResultFromAng(f32 ang)
 {
 	if (ang < 89.0f)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -126,10 +126,10 @@ void TRoulette::switchStop()
 
 void TRoulette::setRollSp(f32 sp)
 {
-	unk13C          = sp;
-	unk148          = 0;
-	unk14A          = 0;
-	unk14C          = 255;
+	unk13C        = sp;
+	unk148        = 0;
+	unk14A        = 0;
+	unk14C        = 255;
 	unk150->unk6C = 0;
 }
 
@@ -155,9 +155,9 @@ static int partsRollCallback(J3DNode* node, int flag)
 		scale[2][0] = 0.0f;
 		scale[2][1] = 0.0f;
 		scale[2][2] = gpCurObject->mScaling.z;
-		f32 rollZ = gpCurObject->getRollAngZ(idx);
-		f32 rollY = gpCurObject->getRollAngY(idx);
-		f32 rollX = gpCurObject->getRollAngX(idx);
+		f32 rollZ   = gpCurObject->getRollAngZ(idx);
+		f32 rollY   = gpCurObject->getRollAngY(idx);
+		f32 rollX   = gpCurObject->getRollAngX(idx);
 		MsMtxSetRotRPH(rot, rollX, rollY, rollZ);
 		PSMTXConcat(jntMtx, rot, jntMtx);
 		PSMTXConcat(jntMtx, scale, jntMtx);
@@ -199,7 +199,8 @@ void TSlotDrum::initNeonMatColor()
 		unk170[i].a = 255;
 		SMS_InitPacket_OneTevColor(
 		    mMActor->getModel(),
-		    getModel()->getModelData()->getMaterialName()->getIndex(matNames[i]),
+		    getModel()->getModelData()->getMaterialName()->getIndex(
+		        matNames[i]),
 		    GX_TEVREG0, &unk170[i]);
 	}
 }
@@ -387,19 +388,11 @@ u32 TItemSlotDrum::touchWater(THitActor* water)
 	if (unk194 != 0)
 		return 1;
 	if (unk1A2 != 0) {
-		// TODO: ~55%. The target keeps lo/hi as int stack locals and computes
-		// hi - lo at runtime (rather than folding to 50), which looks like an
-		// inlined random-in-range helper that isn't identified yet.
-		int lo   = 100;
-		int hi   = 150;
-		unk1A4   = lo + (int)((f32)(hi - lo) * ((f32)rand() * (1.0f / 32768.0f)));
+		unk1A4 = TMsRange<s32>(100, 150).rand();
 		for (int i = 0; i < unk148; i++) {
 			unk19F[i] = 1;
 			unk19C[i] = 0;
-			f32 spLo  = 0.5f;
-			f32 spHi  = 0.8f;
-			unk138[i] = unk158
-			          * (spLo + (spHi - spLo) * ((f32)rand() * (1.0f / 32768.0f)));
+			unk138[i] = unk158 * TMsRange<f32>(0.5f, 0.8f).rand();
 		}
 		unk1A2 = 0;
 	}
@@ -670,9 +663,9 @@ void TDonchou::calcRootMatrix()
 				gpMSound->startSoundActor(MSD_SE_SY_DONCHO_OPEN, &mPosition, 0,
 				                          nullptr, 0, 4);
 				mMActor->setBck("donchou");
-				gpMarDirector->fireStartDemoCamera("どんちょカメラ", &mPosition,
-				                                   -1, 0.0f, true, nullptr, 0,
-				                                   nullptr, JDrama::TFlagT<u16>(0));
+				gpMarDirector->fireStartDemoCamera(
+				    "どんちょカメラ", &mPosition, -1, 0.0f, true, nullptr, 0,
+				    nullptr, JDrama::TFlagT<u16>(0));
 				J3DFrameCtrl* fc = mMActor->getFrameCtrl(0);
 				fc->setRate(0.5f * fc->getRate());
 			}
@@ -797,8 +790,8 @@ void TCloset::moveObject()
 									return;
 							}
 							unk16C = 1;
-							gpMSound->startSoundSystemSE(MSD_SE_SY_CLEAR_SIGN_BIG,
-							                             0, nullptr, 0);
+							gpMSound->startSoundSystemSE(
+							    MSD_SE_SY_CLEAR_SIGN_BIG, 0, nullptr, 0);
 						}
 					}
 				}
@@ -909,7 +902,7 @@ void TSirenabossWall::initMapObj()
 	TMapObjBase::initMapObj();
 	mMActor->offMakeDL();
 	MActorAnmData* anmData = mMActorKeeper->getMActorAnmData();
-	mMultiBtk               = new TMultiBtk(3, getModel()->getModelData());
+	mMultiBtk              = new TMultiBtk(3, getModel()->getModelData());
 	for (int i = 0; i <= 2; i++) {
 		J3DAnmTextureSRTKey* data;
 		if (i < anmData->getUnk38()->getAnmNum())
@@ -937,7 +930,7 @@ void TSirenaCasinoRoof::initMapObj()
 	TMapObjBase::initMapObj();
 	mMActor->offMakeDL();
 	MActorAnmData* anmData = mMActorKeeper->getMActorAnmData();
-	mMultiBtk               = new TMultiBtk(3, getModel()->getModelData());
+	mMultiBtk              = new TMultiBtk(3, getModel()->getModelData());
 	for (int i = 0; i <= 2; i++) {
 		J3DAnmTextureSRTKey* data;
 		if (i < anmData->getUnk38()->getAnmNum())
@@ -1020,8 +1013,8 @@ void TChestRevolve::control()
 BOOL TPanelRevolve::receiveMessage(THitActor* actor, u32 message)
 {
 	if (isState(1)) {
-		gpMSound->startSoundActor(MSD_SE_OBJ_PANEL_ROLL, &mPosition, 0,
-		                          nullptr, 0, 4);
+		gpMSound->startSoundActor(MSD_SE_OBJ_PANEL_ROLL, &mPosition, 0, nullptr,
+		                          0, 4);
 		mState = 2;
 		startAnim(1);
 		removeMapCollision();
@@ -1032,8 +1025,8 @@ BOOL TPanelRevolve::receiveMessage(THitActor* actor, u32 message)
 void TPanelRevolve::touchPlayer(THitActor* actor)
 {
 	if (marioHipAttack() && isState(1)) {
-		gpMSound->startSoundActor(MSD_SE_OBJ_PANEL_ROLL, &mPosition, 0,
-		                          nullptr, 0, 4);
+		gpMSound->startSoundActor(MSD_SE_OBJ_PANEL_ROLL, &mPosition, 0, nullptr,
+		                          0, 4);
 		mState = 2;
 		startAnim(1);
 		removeMapCollision();

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -3,7 +3,9 @@
 #include <Enemy/Telesa.hpp>
 #include <MoveBG/ItemManager.hpp>
 #include <JSystem/JMath.hpp>
+#include <Strategic/Strategy.hpp>
 #include <dolphin/mtx.h>
+#include <string.h>
 #include <Map/Map.hpp>
 #include <MSound/MSound.hpp>
 #include <MSound/SoundEffects.hpp>
@@ -69,6 +71,38 @@ TRoulette::TRoulette(const char* name)
 		unk14C = 255;
 		unk142 = 1;
 	}
+}
+
+void TRoulette::initMapObj()
+{
+	mPosition.y += 500.0f;
+	TMapObjBase::initMapObj();
+	for (u16 i = 0; i < getModel()->getModelData()->getMaterialNum(); i++) {
+		if (strstr(getModel()->getModelData()->getMaterialName()->getName(i),
+		           "_switch")
+		    != nullptr) {
+			SMS_InitPacket_OneTevColor(mMActor->getModel(), i, GX_TEVREG0,
+			                           (GXColorS10*)&unk148);
+		}
+	}
+	TRouletteSw* sw = new TRouletteSw("ルーレットスイッチ");
+	if (sw != nullptr) {
+		sw->unk68 = this;
+		sw->unk6C = 0;
+	}
+	unk150 = sw;
+	JDrama::TNameRefGen::search<TIdxGroupObj>("オブジェクトグループ")
+	    ->getChildren()
+	    .push_back(unk150);
+	f32 attackR = 500.0f;
+	f32 attackH = 100.0f;
+	if (gpApplication.mCurrArea.unk0 == 14) {
+		attackR = 40.0f;
+		attackH = 80.0f;
+	}
+	unk150->initHitActor(0x4000019A, 2, 0x80000000, attackR, attackH, attackR,
+	                     attackH);
+	unk150->offHitFlag(1);
 }
 
 void TRoulette::moveObject()

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -490,6 +490,21 @@ void TCloset::initMapObj()
 	initAnmSound();
 }
 
+void TCloset::calcRootMatrix()
+{
+	gpCurObject     = this;
+	J3DModel* model = getModel();
+	Mtx mtx;
+	MsMtxSetXYZRPH(mtx, mPosition.x, mPosition.y + unk14C, mPosition.z,
+	               mRotation.x, mRotation.y, mRotation.z);
+	PSMTXCopy(mtx, model->getBaseTRMtx());
+	model->setBaseScale(mScaling);
+	mtx[1][3] += unk14C;
+	if (unk16C != 0 && mMActor->checkCurAnm("closetopen", 0)
+	    && mMActor->curAnmEndsNext(0, 0))
+		mMapCollisionWarp->remove();
+}
+
 u32 TCloset::touchWater(THitActor* water)
 {
 	if (unk16C != 0)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -13,6 +13,7 @@
 #include <MSound/MSoundBGM.hpp>
 #include <MSound/BackgroundMusic.hpp>
 #include <Player/MarioAccess.hpp>
+#include <M3DUtil/InfectiousStrings.hpp>
 #include <M3DUtil/MActorData.hpp>
 #include <Map/MapCollisionEntry.hpp>
 #include <MarioUtil/MathUtil.hpp>

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -9,6 +9,7 @@
 #include <Map/Map.hpp>
 #include <MSound/MSound.hpp>
 #include <MSound/SoundEffects.hpp>
+#include <MSound/MSSetSound.hpp>
 #include <MSound/MSoundBGM.hpp>
 #include <MSound/BackgroundMusic.hpp>
 #include <Player/MarioAccess.hpp>

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -5,7 +5,10 @@
 #include <MSound/SoundEffects.hpp>
 #include <Player/MarioAccess.hpp>
 #include <M3DUtil/MActorData.hpp>
+#include <Map/MapCollisionEntry.hpp>
+#include <MarioUtil/MathUtil.hpp>
 #include <Strategic/ObjModel.hpp>
+#include <JSystem/JDrama/JDRNameRefGen.hpp>
 
 // Definition order in this file is the REVERSE of the order symbols appear in
 // mario.MAP, because MoveBG is compiled with -inline deferred.
@@ -19,7 +22,7 @@ TSirenaRollMapObj::TSirenaRollMapObj(const char* name)
     , unk148(0)
     , unk14C(0.0f)
     , unk150(0.0f)
-    , unk154(0.5f)
+    , unk154(1.0f)
     , unk158(10.0f)
     , unk15C(0.1f)
     , unk160(0.2f)
@@ -34,6 +37,55 @@ TCloset::TCloset(const char* name)
     , unk16C(false)
     , unk16D(0)
 {
+}
+
+TSakuCasino::TSakuCasino(const char* name)
+    : TMapObjBase(name)
+    , unk138(nullptr)
+    , unk13C(0)
+    , unk140(0.0f)
+    , unk144(nullptr)
+{
+}
+
+void TSakuCasino::initMapObj()
+{
+	unk140 = 0.0f;
+	unk13C = 0;
+	TMapObjBase::initMapObj();
+	getModel();
+	Mtx mtx;
+	MsMtxSetXYZRPH(mtx, mPosition.x, 2.0f * unk140 + mPosition.y, mPosition.z,
+	               mRotation.x, mRotation.y, mRotation.z);
+	unk138 = new TMapCollisionWarp();
+	unk138->init("/mapObj/SakuCasino", 0, this);
+	PSMTXCopy(mtx, unk138->unk20);
+	unk138->setUp();
+}
+
+void TSakuCasino::loadAfter()
+{
+	TMapObjBase::loadAfter();
+	unk144 = JDrama::TNameRefGen::search<TCasinoPanelGate>("pazul");
+}
+
+void TSakuCasino::calcRootMatrix()
+{
+	J3DModel* model = getModel();
+	Mtx mtx;
+	MsMtxSetXYZRPH(mtx, mPosition.x, mPosition.y + unk140, mPosition.z,
+	               mRotation.x, mRotation.y, mRotation.z);
+	PSMTXCopy(mtx, model->getBaseTRMtx());
+	model->setBaseScale(mScaling);
+	mtx[1][3] += unk140;
+	if (unk144 != nullptr && unk144->unk16D != 0) {
+		unk13C = 1;
+		unk138->remove();
+	}
+	if (unk13C != 0) {
+		unk140 -= 1.0f;
+		mScaling.y *= 0.99f;
+	}
 }
 
 void TSirenabossWall::initMapObj()

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -20,6 +20,68 @@
 
 static TSirenaRollMapObj* gpCurObject;
 
+BOOL TRouletteSw::receiveMessage(THitActor* sender, u32 message)
+{
+	if (message == 1) {
+		unk6C = 1;
+		return 1;
+	}
+	return 0;
+}
+
+void TRouletteSw::perform(u32 cue, JDrama::TGraphics* graphics)
+{
+	THitActor::perform(cue, graphics);
+	unk68->switchStop();
+}
+
+TRoulette::TRoulette(const char* name)
+    : TMapObjBase(name)
+    , unk138(500.0f)
+    , unk13C(0.0f)
+    , unk140(0)
+    , unk141(0)
+    , unk142(0)
+    , unk144(0.2f)
+    , unk150(nullptr)
+{
+	unk148 = 0;
+	unk14A = 0;
+	unk14C = 0;
+	unk14E = 255;
+	if (gpApplication.mCurrArea.unk0 == 14 && gpMarDirector->unk7D == 1) {
+		unk141 = 1;
+		unk14C = 255;
+	}
+	if (gpApplication.mCurrArea.unk0 == 56) {
+		unk14C = 255;
+		unk142 = 1;
+	}
+}
+
+void TRoulette::perform(u32 cue, JDrama::TGraphics* graphics)
+{
+	TMapObjBase::perform(cue, graphics);
+	unk150->perform(cue, graphics);
+}
+
+void TRoulette::calcRootMatrix()
+{
+	J3DModel* model = getModel();
+	MsMtxSetXYZRPH(model->getBaseTRMtx(), mPosition.x, mPosition.y, mPosition.z,
+	               mRotation.x, mRotation.y, mRotation.z);
+	model->setBaseScale(mScaling);
+}
+
+void TRoulette::setRollSp(f32 sp)
+{
+	unk13C          = sp;
+	unk148          = 0;
+	unk14A          = 0;
+	unk14C          = 255;
+	unk150->unk6C = 0;
+}
+
 static int partsRollCallback(J3DNode* node, int flag)
 {
 	if (flag == 0) {

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -7,6 +7,8 @@
 #include <M3DUtil/MActorData.hpp>
 #include <Map/MapCollisionEntry.hpp>
 #include <MarioUtil/MathUtil.hpp>
+#include <MarioUtil/PacketUtil.hpp>
+#include <JSystem/JUtility/JUTNameTab.hpp>
 #include <Strategic/ObjModel.hpp>
 #include <JSystem/JDrama/JDRNameRefGen.hpp>
 #include <JSystem/J3D/J3DGraphAnimator/J3DJoint.hpp>
@@ -136,6 +138,50 @@ TSlotDrum::TSlotDrum(const char* name)
     : TSirenaRollMapObj(name)
     , unk194(0)
 {
+}
+
+void TSlotDrum::initNeonMatColor()
+{
+	const char* matNames[3] = { "_NEON_A", "_NEON_B", "_NEON_C" };
+	for (int i = 0; i < 3; i++) {
+		unk170[i].r = 120;
+		unk170[i].g = 230;
+		unk170[i].b = 255;
+		unk170[i].a = 255;
+		SMS_InitPacket_OneTevColor(
+		    mMActor->getModel(),
+		    getModel()->getModelData()->getMaterialName()->getIndex(matNames[i]),
+		    GX_TEVREG0, &unk170[i]);
+	}
+}
+
+void TSlotDrum::initMapObj()
+{
+	unk148 = 3;
+	unk14C = 400.0f;
+	unk150 = mPosition.y;
+	unk194 = 0;
+	unk154 = 2.0f;
+	unk158 = 10.0f;
+	unk15C = 0.1f;
+	unk160 = 0.5f;
+	unk164 = 0;
+	unk168 = 90;
+	unk138 = new f32[unk148];
+	unk13C = new f32[unk148];
+	for (int i = 0; i < unk148; i++) {
+		unk138[i] = 0.0f;
+		unk13C[i] = 90.0f * (i + 1);
+		unk188[i] = 0.0f;
+	}
+	TMapObjBase::initMapObj();
+	for (u8 i = 0; i < getModel()->getModelData()->getJointNum(); i++)
+		;
+	for (int i = 1; i <= unk148; i++)
+		mMActor->setJointCallback(i, partsRollCallback);
+	unk140 = mDamageRadius / 3.0f;
+	unk144 = mDamageHeight;
+	initNeonMatColor();
 }
 
 void TSlotDrum::calcRootMatrix()

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -9,6 +9,9 @@
 #include <MarioUtil/MathUtil.hpp>
 #include <Strategic/ObjModel.hpp>
 #include <JSystem/JDrama/JDRNameRefGen.hpp>
+#include <System/Application.hpp>
+#include <System/MarDirector.hpp>
+#include <math.h>
 
 // Definition order in this file is the REVERSE of the order symbols appear in
 // mario.MAP, because MoveBG is compiled with -inline deferred.
@@ -29,6 +32,48 @@ TSirenaRollMapObj::TSirenaRollMapObj(const char* name)
     , unk164(1)
 {
 	gpCurObject = nullptr;
+}
+
+TDonchou::TDonchou(const char* name)
+    : TMapObjBase(name)
+    , unk138(nullptr)
+    , unk13C(0)
+    , unk140(0.0f)
+    , unk14C(0)
+{
+}
+
+void TDonchou::initMapObj()
+{
+	unk140 = 0.0f;
+	unk13C = 0;
+	unk148 = nullptr;
+	unk144 = nullptr;
+	TMapObjBase::initMapObj();
+	getModel();
+	Mtx mtx;
+	MsMtxSetXYZRPH(mtx, mPosition.x, 2.0f * unk140 + mPosition.y, mPosition.z,
+	               mRotation.x, mRotation.y, mRotation.z);
+	unk138 = new TMapCollisionWarp();
+	unk138->init("/mapObj/Donchou", 0, this);
+	PSMTXCopy(mtx, unk138->unk20);
+	unk138->setUp();
+}
+
+void TDonchou::loadAfter()
+{
+	TMapObjBase::loadAfter();
+	if (gpApplication.mCurrArea.unk0 == 14 && gpMarDirector->unk7D == 0) {
+		unk144 = JDrama::TNameRefGen::search<TSlotDrum>("srotdram");
+		unk148 = JDrama::TNameRefGen::search<TItemSlotDrum>("itemsrotdram");
+	}
+}
+
+u32 TDonchou::touchWater(THitActor* water)
+{
+	if (fabsf(mPosition.z - water->mPosition.z) < 50.0f)
+		return 1;
+	return 0;
 }
 
 TCloset::TCloset(const char* name)

--- a/src/MoveBG/MapObjSirena.cpp
+++ b/src/MoveBG/MapObjSirena.cpp
@@ -371,6 +371,17 @@ void TItemSlotDrum::calcRootMatrix()
 	model->setBaseScale(mScaling);
 }
 
+void TItemSlotDrum::loadAfter()
+{
+	TMapObjBase::loadAfter();
+	for (int i = 0; i < 6; i++) {
+		TMapObjBaseManager::newAndRegisterObj(
+		    "coin", JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f),
+		    JGeometry::TVec3<f32>(0.0f, 0.0f, 0.0f),
+		    JGeometry::TVec3<f32>(0.5f, 0.5f, 0.5f));
+	}
+}
+
 u32 TItemSlotDrum::touchWater(THitActor* water)
 {
 	if (unk194 != 0)


### PR DESCRIPTION
Decompiles `MoveBG/MapObjSirena.cpp`, the casino/Sirena-beach interactive map objects — slot machines, item drum, roulette, closets, casino panel gate, boss-Boo painting, warp actor, and the shared roll/switch machinery.

**~97% matched, 56/93 functions at 100%.** Every function and every symbol in the TU is implemented. The remaining sub-100% functions are stack-frame-size and register-allocation residuals (instruction streams and logic match).

### Approach (per `docs/PROGRAM_STRUCTURE_REVVING.md`)

- **Full symbol coverage from `mario.MAP`**, including the UNUSED ones: `TItemSlotDrum::getDrumResult`/`getSlotResult` (fully inlined into `generateItem`), the `TMsRange<f32>`/`TMsRange<s32>` dtors, and the UNUSED data `MtxCalcTypeName` / `SMS_NO_MEMORY_MESSAGE` (via `M3DUtil/InfectiousStrings.hpp`).
- **Definition order is the reverse of the map** for this TU (`MoveBG` is `-inline deferred`), verified against `MoveBG/MapObjPole.cpp`.
- **Scope-correct placement**: weak symbols in-class in the header, globals out-of-line, `gpCurObject` a file static. This matched the implicit dtors and their `@32@` thunks for free.
- **Rogue includes** `<MSound/MSSetSound.hpp>` + `<MSound/MSoundBGM.hpp>` (as `MapObjSample.cpp` does) to match `__sinit`'s JAL sound-list registrations.

### Notable bits

- **`TMsRange<T>`** is the random-in-range helper (per review): `T rand() const { T r = mMax - mMin; return mMin + (T)((f32)r * MsRandF()); }`. It only ever appears fully inlined, which is why its two dtors were the sole UNUSED trace.
- **Hierarchy**: `TSirenaRollMapObj : TMapObjBase` with `getRollAng{X,Y,Z}` virtuals; `TSlotDrum` / `TCasinoPanelGate` / `TCloset` derive from it, and `TItemSlotDrum : TSlotDrum` (its ctor writes the `TSlotDrum` vtable first). `TWarpAreaActor` / `TRouletteSw : THitActor`, `TPictureTelesa : TWaterHitPictureHideObj`.
- **`generateItem`** reads the stopped symbols via `getSlotResult` and either fires the jackpot fanfare, spawns a Telesa manager, scatters coins in an arc (Y-rotation matrix from `JMASSin`/`JMASCos` + `PSMTXMultVec`, random upward velocity via `TMsRange`), or plays the no-win jingle. The roulette registers its hit-switch through the `TIdxGroupObj` child list.

### Known residuals

Stack-frame size and register allocation on the sub-100% functions. Two data notes: (1) my hand-built rotation/scale matrices pool a few extra `1.0f`/`0.0f` into `.rodata`, which ripples the string offsets in the diff; (2) `TWaterHitPictureHideObj::getObjAppearPos` is declared non-const in `MoveBG/MapObjHide.hpp` but the target mangles it `const`, so it shows as an extra symbol here — left alone since that header belongs to another TU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
