### PR TITLE
GC2D/Card*: shared header fixes and matching work

### DIFF
--- a/include/GC2D/CardLoad.hpp
+++ b/include/GC2D/CardLoad.hpp
@@ -94,10 +94,9 @@ public:
 	/* 0x208 */ J2DPane* unk208;
 	/* 0x20C */ u16 unk20C[11];
 	/* 0x222 */ u8 unk222[11];
-	/* 0x22E */ s16 unk22E[8];
-	/* 0x23E */ char unk23E[0x248 - 0x23E];
-	/* 0x248 */ u8 unk248[8];
-	/* 0x250 */ char unk24D[0x258 - 0x250];
+	/* 0x22E */ u16 unk22E[13];
+	/* 0x248 */ u8 unk248[13];
+	/* 0x255 */ char unk255[0x258 - 0x255];
 	/* 0x258 */ u16 unk258;
 	/* 0x25C */ J2DPane* unk25C;
 	/* 0x260 */ JUTRect unk260;

--- a/include/M3DUtil/InfectiousStrings.hpp
+++ b/include/M3DUtil/InfectiousStrings.hpp
@@ -1,11 +1,13 @@
 #ifndef M3DUTIL_INFECTIOUS_STRINGS_HPP
 #define M3DUTIL_INFECTIOUS_STRINGS_HPP
 
-// TODO: these should live in some other header and infect various TUs, but we
-// don't know which one yet
-static const char* dummyMactorStringValue1 = "\0\0\0\0\0\0\0\0\0\0\0";
-static const char* SMS_NO_MEMORY_MESSAGE   = "メモリが足りません\n";
+// Every retail TU carrying these mtx calc type names also carries the pair in
+// System/DummyStrings.hpp, and always ahead of them, so that header comes
+// first here.
+#include <System/DummyStrings.hpp>
 
+// TODO: this should live in some other header and infect various TUs, but we
+// don't know which one yet
 static const char* MtxCalcTypeName[] = {
 	"MActorMtxCalcType_Basic クラシックスケールＯＮ",
 	"MActorMtxCalcType_Softimage クラシックスケールＯＦＦ",

--- a/include/System/DummyStrings.hpp
+++ b/include/System/DummyStrings.hpp
@@ -1,0 +1,16 @@
+#ifndef SYSTEM_DUMMY_STRINGS_HPP
+#define SYSTEM_DUMMY_STRINGS_HPP
+
+// These two are separate from the MActor mtx-calc type names in
+// M3DUtil/InfectiousStrings.hpp. Scanning the retail objects for the literals:
+// 142 carry both sets, 40 carry only this pair, and none carry only the mtx
+// calc names -- a strict superset, so this pair lives in its own, much more
+// widely included header, and the mtx calc one pulls it in. TUs needing only
+// this pair include GC2D/CardSave, GC2D/Option and MSound/MSound.
+//
+// TODO: still no idea what header this actually was.
+
+static const char* dummyMactorStringValue1 = "\0\0\0\0\0\0\0\0\0\0\0";
+static const char* SMS_NO_MEMORY_MESSAGE   = "メモリが足りません\n";
+
+#endif

--- a/include/System/StageUtil.hpp
+++ b/include/System/StageUtil.hpp
@@ -38,6 +38,13 @@ static const u8 scShineTableMonte[]
     = { 0x3C, 0x41, 0x3E, 0x3D, 0x40, 0x3F, 0x42, 0x43 };
 static const u8 scShineTableMonteEtc[] = { 0x6A, 0x44, 0x45 };
 
+static const u8* scShineConvTable[] = {
+	scShineTableAirport, nullptr,
+	scShineTableBianco,  scShineTableRicco,
+	scShineTableMamma,   scShineTablePinna,
+	scShineTableSirena,  scShineTableMonte,
+	scShineTableMare,    nullptr,
+};
 static const u8* scEtcShineConvTable[] = {
 	nullptr,
 	scShineTableDolpicEtc,
@@ -50,18 +57,11 @@ static const u8* scEtcShineConvTable[] = {
 	scShineTableMareEtc,
 	nullptr,
 };
-static const u8* scShineConvTable[] = {
-	scShineTableAirport, nullptr,
-	scShineTableBianco,  scShineTableRicco,
-	scShineTableMamma,   scShineTablePinna,
-	scShineTableSirena,  scShineTableMonte,
-	scShineTableMare,    nullptr,
-};
 
 // Yes, these were defined in a header and marked as static instead of inline
 // by mistake. This is probably the right header, I think.
 
-static const u32 scScenarioNameTable[] = {
+static u32 scScenarioNameTable[] = {
 	0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  0x8,  0x9,  0x32, 0x33,
 	0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0xA,  0xB,  0xC,  0xD,
 	0xE,  0xF,  0x10, 0x11, 0x12, 0x13, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D,

--- a/src/GC2D/CardLoad.cpp
+++ b/src/GC2D/CardLoad.cpp
@@ -117,15 +117,12 @@ void TCardLoad::load(JSUMemoryInputStream& stream)
 
 	for (int i = 0; i < 11; ++i) {
 		unk20C[i] = 25 * i + 150;
+		if (i > 4)
+			unk20C[i] += 20;
 		unk222[i] = 4;
 	}
 
-	for (int i = 0; i < 8; ++i) {
-		unk22E[i] = 400 * i;
-		unk248[i] = 4;
-	}
-
-	for (int i = 0; i < 8; ++i) {
+	for (int i = 0; i < 13; ++i) {
 		unk22E[i] = 400 * i;
 		unk248[i] = 4;
 	}
@@ -490,23 +487,22 @@ void TCardLoad::perform(u32 cue, JDrama::TGraphics* graphics)
 		switch (unk14) {
 		case 0: {
 			changeScene();
-			int alpha1 = unk25C->getAlpha();
-			if (unk275 && alpha1 < 255) {
-				alpha1 += 8;
-				if (alpha1 > 255)
-					alpha1 = 255;
-				unk25C->setAlpha(alpha1);
+			int alpha = unk25C->getAlpha();
+			if (unk275 && alpha < 255) {
+				alpha += 8;
+				if (alpha > 255)
+					alpha = 255;
+				unk25C->setAlpha(alpha);
 			}
 
-			int alpha2 = unk25C->getAlpha();
-			if (!unk275 && alpha2 > 0) {
-				alpha2 -= 8;
-				if (alpha2 < 0)
-					alpha2 = 0;
-				unk25C->setAlpha(alpha2);
+			if (!unk275 && alpha > 0) {
+				alpha -= 8;
+				if (alpha < 0)
+					alpha = 0;
+				unk25C->setAlpha(alpha);
 			}
 
-			if (unk25C->getAlpha() != 0) {
+			if (alpha != 0) {
 				// TODO: copy-pasta from TArrowControl::calcMoveX? inline?
 				int iVar9 = unk274;
 				int iVar3 = unk274 < 50 ? iVar9 : 100 - iVar9;
@@ -521,7 +517,6 @@ void TCardLoad::perform(u32 cue, JDrama::TGraphics* graphics)
 					unk274 = 0;
 			}
 
-			int alpha = unk25C->getAlpha();
 			if (unk1C == 19 || unk1C == 12 || unk1C == 13 || unk1C == 3
 			    || unk1C == 4 || unk1C == 5 || unk1C == 45 || unk1C == 16) {
 				unk284->offCollision();
@@ -781,6 +776,14 @@ void TCardLoad::perform(u32 cue, JDrama::TGraphics* graphics)
 	}
 }
 
+// TODO: retail compiles this switch to an eight entry jump table, with the
+// slots for cases 5 through 7 pointing at the default, while we get a compare
+// chain. That one difference accounts for nearly all of the remaining diff --
+// the rest is register allocation downstream of it. The case set matches
+// retail (our chain does range-check 5 through 7, so they are not being
+// pruned), the body layout order matches, and the frame is 0x20 bytes smaller
+// than retail's. Typing the state as an enum spanning 0-7, moving the empty
+// cases to the front, and making the field unsigned all fail to flip it.
 bool TCardLoad::titleDraw()
 {
 	switch (unk18) {
@@ -792,11 +795,10 @@ bool TCardLoad::titleDraw()
 		for (int i = 0; i < 13; ++i) {
 			switch (unk248[i]) {
 			case 4:
-				if (unk22E[i] < unk258) {
-					TExPane* pane = unk1D4[i];
-					pane->getPane()->show();
-					JUTRect bounds = pane->getPane()->getBounds();
-					pane->setPaneAlpha(40, 180, 0);
+				if (unk258 > unk22E[i]) {
+					unk1D4[i]->getPane()->show();
+					JUTRect bounds = unk1D4[i]->getPane()->getBounds();
+					unk1D4[i]->setPaneAlpha(40, 180, 0);
 					unk248[i] = 0;
 				}
 				break;
@@ -924,7 +926,7 @@ bool TCardLoad::titleDraw()
 		break;
 	}
 
-	return unk18 - 5;
+	return unk18 > 4;
 }
 
 void TCardLoad::makeBuffer(J2DTextBox* text_box, int size)
@@ -2084,8 +2086,8 @@ void TCardLoad::setSelected(u8 param_1)
 
 void TCardLoad::changeScene()
 {
-	u32 prevUnk1C = unk1C;
-	int prevUnk0  = unk10;
+	TEProgress prevUnk1C = unk1C;
+	int prevUnk0         = unk10;
 	switch (prevUnk1C) {
 	case PROGRESS_UNK30:
 		gpCardManager->readOptionBlock();
@@ -2337,7 +2339,7 @@ void TCardLoad::changeScene()
 
 			case 3:
 				for (int i = 0; i < 3; ++i)
-					if (unkB0 == i)
+					if (i == unkB0)
 						unk728[i]->show();
 					else
 						unk728[i]->hide();

--- a/src/GC2D/CardSave.cpp
+++ b/src/GC2D/CardSave.cpp
@@ -20,6 +20,7 @@
 #include <MSound/MSound.hpp>
 
 // rogue includes needed for matching sinit & bss
+#include <System/DummyStrings.hpp>
 #include <MSound/MSSetSound.hpp>
 #include <MSound/MSoundBGM.hpp>
 


### PR DESCRIPTION
Improving matching on TUs that already exist rather than starting new ones, as discussed. The Card save/load screens had the largest concentration of non-trivial mismatch in game code, and most of what was wrong turned out to be shared-header problems rather than anything in the TUs themselves.

## Shared headers

**`scScenarioNameTable` is not const.** Retail links it into `.data` — see `.data 0x28` in the extracted `PauseMenu2.o`. Marking it const put it in `.rodata` in every TU including `StageUtil.hpp`, displacing the string pool behind it: in CardLoad every literal sat 0x118 too high, so every instruction addressing one came out with the wrong offset. Dropping the const is the single largest change here.

`mario.MAP` also lists `scShineConvTable` ahead of `scEtcShineConvTable` in CardLoad's `.data` closure, so the two definitions are swapped to match.

**The dummy strings are not in the same header as the mtx calc type names.** Retail `CardSave.o` opens `.rodata` with `dummyMactorStringValue1` and `SMS_NO_MEMORY_MESSAGE` and then goes straight to its own literals — no mtx calc names. Scanning every retail object for the literals:

| | count |
| --- | --- |
| carry both sets | 142 |
| carry only the dummy pair | 40 |
| carry only the mtx calc names | 0 |

A strict superset, so the pair lives in its own much more widely included header and the mtx calc one pulls it in. Split accordingly. CardSave had neither, which pushed every string in that TU down by 0x20.

## CardLoad

- `load()` wrote the 400-step loop out twice with a bound of 8. Retail unrolls the first eight iterations and leaves a five-iteration loop behind, i.e. one loop with a bound of 13 — which is also what the 0x22E and 0x248 arrays actually hold, so the padding between them disappears. The 25-step loop was missing its `if (i > 4) += 20`.
- `titleDraw()` returned `unk18 - 5`, true for every state except 5. Retail ends with the `eqv`/`subfc`/`addze`/`clrlwi` sequence MWCC emits for a plain `>` against 4, so it asks whether the sequence has run past its last state. Also caches `unk1D4[i]` in a local where retail reloads it before each of three uses, and `unk22E` is unsigned (`lhzx` + `cmplw`).
- `perform()` read the pane alpha three separate times plus a fourth read nothing used. Retail loads it once with `lbzu` and threads that value through both fade branches and the bounds check, re-testing `unk275` rather than using an `else`.
- `changeScene()` compared `unkB0 == i` where retail puts the counter first, and held the entering progress in a `u32` so the final comparison came out unsigned; it is a `TEProgress`.

## Results

| | before | after |
| --- | --- | --- |
| `TCardLoad::load` | 92.06% | 98.00% |
| `TCardLoad::titleDraw` | 90.83% | 95.27% |
| `TCardLoad::perform` | 94.85% | 97.52% |
| `TCardLoad::loadAfter` | 99.88% | **100%** |
| `TCardLoad::changeScene` | 99.80% | 99.95% |
| CardLoad unit | 97.37% | 98.39% |
| CardSave data | 29.00% | 49.78% |
| PauseMenu2 data | 34.84% | 75.57% |
| ConsoleStr data | 7.43% | 58.86% |
| Total matched_data | 48.47% | 48.61% |

`TPauseMenu2::load` 98.16% → 99.95% and `TConsoleStr::load` 98.00% → 99.53% come along with the header fix, plus small gains in WaterGun, Item, MapObjTown and emario.

**One regression to disclose:** `TMarDirector::setupObjects` 97.16% → 97.09%. Pure register renumbering from the data layout shift, in a function that is already structurally wrong (frame 0xb28 vs 0x990).

## What is left, and one question

The residual across both TUs is now almost entirely frame-size deltas — `waitForChoice` has 7 hard diffs (all scheduling) and 345 soft ones that are one constant stack offset; `execMovement_` is 12 register copies and 1135 offset shifts. Leaving that alone per the tips doc.

`titleDraw` has a `TODO` on the one structural thing I could not crack: retail compiles its switch to an eight-entry jump table (slots 5–7 pointing at the default) where we get a compare chain. The case set matches retail, the body layout order matches, and typing the state as an enum spanning 0–7, moving the empty cases to the front, and making the field unsigned all fail to flip it.

**Question on the symbol-order gate.** `validate-symbol-order.py` fails CardLoad on a missing `__ct__14JSUInputStreamFv`, which the map has as a linked weak symbol of 0x24 bytes in that TU. This is pre-existing — I verified the identical failure on `main` with every change here reverted — but `check-changed-symbol-order.py` does not baseline, so any PR touching `CardLoad.cpp` trips it. My guess is the `// fabricated` default ctor in `JSUMemoryInputStream.hpp` letting MWCC inline the whole base chain instead of emitting `JSUInputStream`'s implicit ctor out of line, but that is a JSystem header and agents are not to touch those, so I left it. Happy to follow whatever you prefer here.

Also noted while auditing UNUSED coverage, all pre-existing and untouched: `TCardLoad::setupTitleScreen` (map 0x110, ours 0x4), `TCardLoad::changePattern` and `TCardSave::changePattern` (map 0xc8, ours 0x4) are still empty stubs, and `scNormalStageTable` (0x28, UNUSED in CardLoad/ConsoleStr/PauseMenu2, linked in SelectMenu and Guide) is missing from `StageUtil.hpp` entirely. I left that one alone since adding it would shift `.data` in SelectMenu, which is locked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
