### PR TITLE
GC2D/BlendPane: decompile matching TU

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1106,7 +1106,7 @@ config.libs = [
             Object(NonMatching, "GC2D/SelectMenu.cpp"),
             Object(NonMatching, "GC2D/SelectDir.cpp"),
             Object(NonMatching, "GC2D/SelectShine2.cpp"),
-            Object(NonMatching, "GC2D/BlendPane.cpp"),
+            Object(Matching, "GC2D/BlendPane.cpp"),
             Object(NonMatching, "GC2D/Guide.cpp"),
             Object(NonMatching, "GC2D/SunGlass.cpp"),
             Object(Matching, "GC2D/ShineFader.cpp"),

--- a/include/GC2D/BlendPane.hpp
+++ b/include/GC2D/BlendPane.hpp
@@ -5,14 +5,11 @@
 #include <JSystem/J2D/J2DPicture.hpp>
 #include <JSystem/JUtility/JUTTexture.hpp>
 
-// Keep the data in a non-polymorphic base so MWCC places the vtable at 0x74.
-struct TBlendPaneData {
-	/* 0x0 */ f32 mBlendStep;
-	/* 0x4 */ f32 mBlendProgress;
-	/* 0x8 */ bool mBlendActive;
-};
+class TBlendPane : public TBoundPane {
+	/* 0x68 */ f32 mBlendStep;
+	/* 0x6C */ f32 mBlendProgress;
+	/* 0x70 */ bool mBlendActive;
 
-class TBlendPane : public TBoundPane, public TBlendPaneData {
 public:
 	TBlendPane(J2DScreen*, u32);
 

--- a/include/GC2D/BlendPane.hpp
+++ b/include/GC2D/BlendPane.hpp
@@ -2,13 +2,34 @@
 #define GC2D_BLEND_PANE_HPP
 
 #include <GC2D/BoundPane.hpp>
+#include <JSystem/J2D/J2DPicture.hpp>
+#include <JSystem/JUtility/JUTTexture.hpp>
 
-class TBlendPane : public TBoundPane {
+// Keep the data in a non-polymorphic base so MWCC places the vtable at 0x74.
+struct TBlendPaneData {
+	/* 0x0 */ f32 mBlendStep;
+	/* 0x4 */ f32 mBlendProgress;
+	/* 0x8 */ bool mBlendActive;
+};
+
+class TBlendPane : public TBoundPane, public TBlendPaneData {
 public:
 	TBlendPane(J2DScreen*, u32);
 
-	virtual void update();
-	void setPaneBlend(s32, JUTTexture*, JUTTexture*);
+	virtual bool update();
+	void setPaneBlend(s32 frames, JUTTexture* texture1, JUTTexture* texture2)
+	{
+		if (texture2 == nullptr) {
+			((J2DPicture*)getPane())->changeTexture(texture1->getTexInfo(), 0);
+		} else {
+			((J2DPicture*)getPane())->changeTexture(texture1->getTexInfo(), 0);
+			((J2DPicture*)getPane())->changeTexture(texture2->getTexInfo(), 1);
+		}
+
+		mBlendActive   = true;
+		mBlendStep     = 1.0f / frames;
+		mBlendProgress = 0.0f;
+	}
 };
 
 #endif

--- a/src/GC2D/BlendPane.cpp
+++ b/src/GC2D/BlendPane.cpp
@@ -1,1 +1,31 @@
+#include <GC2D/BlendPane.hpp>
+#include <JSystem/J2D/J2DScreen.hpp>
 
+TBlendPane::TBlendPane(J2DScreen* screen, u32 tag)
+    : TBoundPane(screen, tag)
+{
+	mBlendActive   = false;
+	mBlendStep     = 0.0f;
+	mBlendProgress = 0.0f;
+}
+
+bool TBlendPane::update()
+{
+	bool result = TBoundPane::update();
+	if (mBlendActive) {
+		if (mBlendProgress >= 1.0f) {
+			mBlendProgress = 1.0f;
+			mBlendActive   = false;
+		}
+
+		f32 inverseProgress;
+		f32 progress;
+		inverseProgress     = 1.0f - (progress = mBlendProgress);
+		J2DPicture* picture = (J2DPicture*)getPane();
+		picture->setBlendKonstColor(progress, inverseProgress, 1.0f, 1.0f);
+		picture->setBlendKonstAlpha(progress, inverseProgress, 1.0f, 1.0f);
+		mBlendProgress += mBlendStep;
+	}
+
+	return (result && !mBlendActive) ? true : false;
+}


### PR DESCRIPTION
## Summary
- decompile `GC2D/BlendPane` and mark the TU matching
- model the MWCC layout so `TBlendPane` has the target `0x78` size and downstream allocations match
- implement the blend update path and inline texture helper

## Verification
- `decomp-diff.py -u mario/GC2D/BlendPane`: 100% for all TU symbols/data
- `validate-symbol-order.py -u mario/GC2D/BlendPane`: PASS, 0 UNUSED symbols
- `ninja baseline` and `ninja changes_all -j 8`: pass
- clang-format and `git diff --check`: pass

This decomp TU is a test of Luna 5.6 to make sure it is ready for decompiling. It was held to full matching and validation standards. BossGesso was not touched.