### PR TITLE
GMSP01: decompile video height getters

### DIFF
--- a/include/System/Resolution.hpp
+++ b/include/System/Resolution.hpp
@@ -3,7 +3,11 @@
 
 #include <dolphin/types.h>
 
+#ifdef VERSION_GMSP01
+u16 SMSGetGCLogoVideoHeight(u32 format);
+#else
 u16 SMSGetGCLogoVideoHeight();
+#endif
 u16 SMSGetGCLogoVideoWidth();
 u16 SMSGetGCLogoRenderHeight();
 u16 SMSGetGCLogoRenderWidth();
@@ -11,11 +15,19 @@ u16 SMSGetTitleRenderHeight();
 u16 SMSGetTitleRenderWidth();
 u16 SMSGetGameRenderHeight();
 u16 SMSGetGameRenderWidth();
+#ifdef VERSION_GMSP01
+u16 SMSGetTitleVideoHeight(u32 format);
+#else
 u16 SMSGetTitleVideoHeight();
+#endif
 u16 SMSGetTitleVideoWidth();
 s32 SMSGetDisplayHeightMax();
 s32 SMSGetDisplayWidthMax();
+#ifdef VERSION_GMSP01
+u16 SMSGetGameVideoHeight(u32 format);
+#else
 u16 SMSGetGameVideoHeight();
+#endif
 u16 SMSGetGameVideoWidth();
 
 #endif

--- a/src/System/MarDirectorSetupObjects.cpp
+++ b/src/System/MarDirectorSetupObjects.cpp
@@ -13,6 +13,9 @@
 #include <JSystem/JKernel/JKRDvdFile.hpp>
 #include <JSystem/JKernel/JKRDvdRipper.hpp>
 #include <System/Resolution.hpp>
+#ifdef VERSION_GMSP01
+#include <dolphin/vi.h>
+#endif
 #include <System/EventWatcher.hpp>
 #include <System/EmitterViewObj.hpp>
 #include <System/RenderModeObj.hpp>
@@ -305,8 +308,13 @@ bool TMarDirector::setupObjects()
 
 		JDrama::TLookAtCamera* cam
 		    = JDrama::TNameRefGen::search<JDrama::TLookAtCamera>("camera 1");
+#ifdef VERSION_GMSP01
+		cam->mAspect = (u16)SMSGetGameVideoWidth() * 0.9134614f
+		               / (u16)SMSGetGameVideoHeight(VIGetTvFormat());
+#else
 		cam->mAspect = (u16)SMSGetGameVideoWidth() * 0.9134614f
 		               / (u16)SMSGetGameVideoHeight();
+#endif
 	}
 
 	unk80 = new JDrama::TViewObjPtrListT<JDrama::TViewObj>("イベントグループ");

--- a/src/System/RenderModeObj.cpp
+++ b/src/System/RenderModeObj.cpp
@@ -24,14 +24,23 @@ JDrama::TRect SMSGetRederRect_Game()
 
 void SMSSetupGCLogoRenderMode(GXRenderModeObj* rmo)
 {
+#ifdef VERSION_GMSP01
+	u32 format    = VIGetTvFormat();
+	rmo->viTVmode = (VITVMode)VI_TVMODE(format, VI_INTERLACE);
+#else
 	rmo->viTVmode        = (VITVMode)VI_TVMODE(VIGetTvFormat(), VI_INTERLACE);
+#endif
 	rmo->fbWidth         = SMSGetGCLogoRenderWidth();
 	rmo->efbHeight       = SMSGetGCLogoRenderHeight();
 	rmo->viWidth         = SMSGetGCLogoVideoWidth();
 	rmo->xFBmode         = VI_XFBMODE_DF;
 	rmo->field_rendering = 0;
 	rmo->aa              = 0;
+#ifdef VERSION_GMSP01
+	JDrama::CalcRenderModeXFBHeight(rmo, SMSGetGCLogoVideoHeight(format));
+#else
 	JDrama::CalcRenderModeXFBHeight(rmo, SMSGetGCLogoVideoHeight());
+#endif
 	JDrama::CalcRenderModeVIXOrigin(rmo);
 	JDrama::CalcRenderModeVIYOrigin(rmo);
 	JDrama::CopyRenderModeSamplePattern(rmo, SMSAASamplePattern_non);
@@ -46,17 +55,31 @@ void SMSSetupGCLogoRenderingInfo(JDrama::TDisplay* param_1)
 
 void SMSSetupTitleRenderMode(GXRenderModeObj* rmo)
 {
+#ifdef VERSION_GMSP01
+	u32 format    = VIGetTvFormat();
+	bool noFilter = format == 0 && OSGetProgressiveMode() == 1;
+#else
 	bool noFilter = VIGetTvFormat() == 0 && OSGetProgressiveMode() == 1;
+#endif
 
+#ifdef VERSION_GMSP01
+	rmo->viTVmode
+	    = (VITVMode)VI_TVMODE(format, noFilter ? VI_PROGRESSIVE : VI_INTERLACE);
+#else
 	rmo->viTVmode = (VITVMode)VI_TVMODE(
 	    VIGetTvFormat(), noFilter ? VI_PROGRESSIVE : VI_INTERLACE);
+#endif
 	rmo->fbWidth         = SMSGetTitleRenderWidth();
 	rmo->efbHeight       = SMSGetTitleRenderHeight();
 	rmo->viWidth         = SMSGetTitleVideoWidth();
 	rmo->xFBmode         = noFilter ? VI_XFBMODE_SF : VI_XFBMODE_DF;
 	rmo->field_rendering = 0;
 	rmo->aa              = 0;
+#ifdef VERSION_GMSP01
+	JDrama::CalcRenderModeXFBHeight(rmo, SMSGetTitleVideoHeight(format));
+#else
 	JDrama::CalcRenderModeXFBHeight(rmo, SMSGetTitleVideoHeight());
+#endif
 	JDrama::CalcRenderModeVIXOrigin(rmo);
 	JDrama::CalcRenderModeVIYOrigin(rmo);
 	JDrama::CopyRenderModeSamplePattern(rmo, SMSAASamplePattern_non);
@@ -74,10 +97,20 @@ void SMSSetupGameRenderingInfo(JDrama::TDisplay* param_1, bool param_2)
 {
 	GXRenderModeObj& rmo = param_1->getRenderMode();
 
+#ifdef VERSION_GMSP01
+	u32 format    = VIGetTvFormat();
+	bool noFilter = format == 0 && OSGetProgressiveMode() == 1;
+#else
 	bool noFilter = VIGetTvFormat() == 0 && OSGetProgressiveMode() == 1;
+#endif
 
+#ifdef VERSION_GMSP01
+	rmo.viTVmode
+	    = (VITVMode)VI_TVMODE(format, noFilter ? VI_PROGRESSIVE : VI_INTERLACE);
+#else
 	rmo.viTVmode = (VITVMode)VI_TVMODE(
 	    VIGetTvFormat(), noFilter ? VI_PROGRESSIVE : VI_INTERLACE);
+#endif
 
 	param_1->onFlag(0x8);
 	if (param_2) {
@@ -91,7 +124,11 @@ void SMSSetupGameRenderingInfo(JDrama::TDisplay* param_1, bool param_2)
 	rmo.efbHeight = SMSGetGameRenderHeight();
 	rmo.viWidth   = SMSGetGameVideoWidth();
 
+#ifdef VERSION_GMSP01
+	JDrama::CalcRenderModeXFBHeight(&rmo, SMSGetGameVideoHeight(format));
+#else
 	JDrama::CalcRenderModeXFBHeight(&rmo, SMSGetGameVideoHeight());
+#endif
 	JDrama::CalcRenderModeVIXOrigin(&rmo);
 	JDrama::CalcRenderModeVIYOrigin(&rmo);
 	if (param_2 || noFilter) {
@@ -108,17 +145,31 @@ void SMSSetupMovieRenderingInfo(JDrama::TDisplay* param_1)
 {
 	GXRenderModeObj& rmo = param_1->getRenderMode();
 
+#ifdef VERSION_GMSP01
+	u32 format    = VIGetTvFormat();
+	bool noFilter = format == 0 && OSGetProgressiveMode() == 1;
+#else
 	bool noFilter = VIGetTvFormat() == 0 && OSGetProgressiveMode() == 1;
+#endif
 
+#ifdef VERSION_GMSP01
+	rmo.viTVmode
+	    = (VITVMode)VI_TVMODE(format, noFilter ? VI_PROGRESSIVE : VI_INTERLACE);
+#else
 	rmo.viTVmode = (VITVMode)VI_TVMODE(
 	    VIGetTvFormat(), noFilter ? VI_PROGRESSIVE : VI_INTERLACE);
+#endif
 	rmo.fbWidth         = SMSGetGameRenderWidth();
 	rmo.efbHeight       = SMSGetGameRenderHeight();
 	rmo.viWidth         = SMSGetGameVideoWidth();
 	rmo.xFBmode         = noFilter ? VI_XFBMODE_SF : VI_XFBMODE_DF;
 	rmo.field_rendering = 0;
 	rmo.aa              = 0;
+#ifdef VERSION_GMSP01
+	JDrama::CalcRenderModeXFBHeight(&rmo, SMSGetGameVideoHeight(format));
+#else
 	JDrama::CalcRenderModeXFBHeight(&rmo, SMSGetGameVideoHeight());
+#endif
 	JDrama::CalcRenderModeVIXOrigin(&rmo);
 	JDrama::CalcRenderModeVIYOrigin(&rmo);
 	JDrama::CopyRenderModeSamplePattern(&rmo, SMSAASamplePattern_non);

--- a/src/System/Resolution.cpp
+++ b/src/System/Resolution.cpp
@@ -3,6 +3,25 @@
 
 u16 SMSGetGameVideoWidth() { return 660; }
 
+#ifdef VERSION_GMSP01
+u16 SMSGetGameVideoHeight(u32 format)
+{
+	u16 ret = 448;
+	switch (format) {
+	case VI_MPAL:
+	case VI_NTSC:
+	case VI_EURGB60:
+		ret = 448;
+		break;
+	case VI_PAL:
+		ret = 530;
+		break;
+	default:
+		break;
+	}
+	return ret;
+}
+#else
 u16 SMSGetGameVideoHeight()
 {
 	u16 ret = 448;
@@ -20,6 +39,7 @@ u16 SMSGetGameVideoHeight()
 	}
 	return ret;
 }
+#endif
 
 // UNUSED
 s32 SMSGetDisplayWidthMax() { return 720; }
@@ -29,7 +49,11 @@ s32 SMSGetDisplayHeightMax() { return 574; }
 
 u16 SMSGetTitleVideoWidth() { return 660; }
 
+#ifdef VERSION_GMSP01
+u16 SMSGetTitleVideoHeight(u32 format) { return SMSGetGameVideoHeight(format); }
+#else
 u16 SMSGetTitleVideoHeight() { return SMSGetGameVideoHeight(); }
+#endif
 
 u16 SMSGetGameRenderWidth() { return 640; }
 
@@ -45,4 +69,11 @@ u16 SMSGetGCLogoRenderHeight() { return 448; }
 
 u16 SMSGetGCLogoVideoWidth() { return 640; }
 
+#ifdef VERSION_GMSP01
+u16 SMSGetGCLogoVideoHeight(u32 format)
+{
+	return SMSGetTitleVideoHeight(format);
+}
+#else
 u16 SMSGetGCLogoVideoHeight() { return SMSGetTitleVideoHeight(); }
+#endif


### PR DESCRIPTION
In GMSP01 the three video *height* getters take the TV format from the caller (`__FUl`) instead of querying VI themselves (`__Fv` in GMSJ01). They were undecompiled, which was two of the six undefined symbols at PAL link time.

`System/Resolution.cpp` is now 12/12 matching for GMSP01 (`SMSGetGCLogoVideoHeight` 0x20, `SMSGetTitleVideoHeight` 0x40, `SMSGetGameVideoHeight` 0x40). Structure is unchanged from the JPN source; only the format source differs, and the GCLogo -> Title -> Game chain still collapses to a single `bl SMSGetGameVideoHeight__FUl` via one-level inlining, as in the retail binary.

Call sites updated so GMSP01 still compiles. Reusing the format each function already queries also improves `RenderModeObj` 74.23% -> 78.86% (`SMSSetupGCLogoRenderMode` 79.58% -> 87.92%, `SMSSetupTitleRenderMode` 81.91% -> 88.21%).

GMSJ01 is unaffected: `Resolution.cpp`, `RenderModeObj.cpp` and `MarDirectorSetupObjects.cpp` all compile to byte-identical objects before and after (checked by compiling both revisions with `-DVERSION_GMSJ01` and comparing).

Verification (GMSP01): `validate-symbol-order.py` passes presence/order/linkage on all three TUs against `marioEU.MAP`; symbol order including the two UNUSED entries matches the map exactly.

Open question: this is the first use of `-DVERSION_GMSP01`, which `configure.py` has always emitted but nothing consumed. Happy to reshape it if you'd prefer a different mechanism for version divergence.

Not addressed:
- Retail PAL derives the format once per function and overrides it via `OSGetConsoleType()` / `OSGetEuRgb60Mode()`. That isn't implemented, so those functions stay non-matching.
- `MarDirectorSetupObjects` goes 96.89% -> 96.85%; the target inlines the call there and we can't inline cross-TU.
- PAL still doesn't link: `OSGetEuRgb60Mode`, `OSSetEuRgb60Mode`, `OSGetLanguage` (OSRtc) remain undefined.
- Unrelated, but `marioEU.MAP` lists `SMSGetDisplayWidthMax`/`SMSGetDisplayHeightMax` as UNUSED at 0x74; the current `return 720` / `return 574` bodies compile to 0x8, so PAL's are probably format-dependent too.