### PR TITLE
feature(decomp): match and link MSL ansi_fp

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -576,7 +576,7 @@ config.libs = [
             Object(Matching, "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/ansi_files.c"),
             Object(Matching, "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/abort_exit.c"),
             Object(Matching, "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/errno.c"),
-            Object(NonMatching, "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common_Embedded/ansi_fp.c"),
+            Object(Matching, "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common_Embedded/ansi_fp.c"),
             Object(Matching, "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common_Embedded/uart_console_io.c"),
             Object(Matching, "PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/buffer_io.c"),
             Object(Matching, "PowerPC_EABI_Support/Msl/MSL_C/PPC_EABI/critical_regions.ppc_eabi.c"),

--- a/include/PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/ansi_fp.h
+++ b/include/PowerPC_EABI_Support/Msl/MSL_C/MSL_Common/ansi_fp.h
@@ -31,6 +31,6 @@ BOOL __less_dec(const decimal*, const decimal*);
 void __minus_dec(decimal*, const decimal*, const decimal*);
 void __num2dec_internal(decimal*, f64); */
 void __num2dec(const decform*, double, decimal*);
-/* f64 __dec2num(const decimal*); */
+double __dec2num(const decimal*);
 
 #endif

--- a/src/PowerPC_EABI_Support/Msl/MSL_C/MSL_Common_Embedded/ansi_fp.c
+++ b/src/PowerPC_EABI_Support/Msl/MSL_C/MSL_Common_Embedded/ansi_fp.c
@@ -122,3 +122,78 @@ void __num2dec(const decform* f, double x, decimal* d)
 
 	d->exp = exp;
 }
+
+// fabricated, UNUSED in the map. Defined after __num2dec so it is codegen'd
+// first, pooling the 0.0/1.0/int-conversion literals into .sdata2 in the
+// original order (@268/@270/@272 before @362/@363) -- required for the DOL
+// to link byte-identical even though the function itself is deadstripped.
+// TODO: incorrect size (0x13c here vs 0x2a4 in the map); the real body
+// likely handled the '0'/'N'/'I' encodings written by __num2dec.
+double __dec2num(const decimal* d)
+{
+	int digits;
+	int var_r4;
+	int chunk;
+	int n;
+	int count;
+	double x;
+	double var_f1;
+	const double* var_r5;
+	const unsigned char* p;
+
+	x = 0.0;
+
+	digits = d->sig.length;
+	if (digits == 0) {
+		return x;
+	}
+
+	var_f1 = 1.0;
+	var_r4 = d->exp;
+	var_r5 = bit_values;
+	if (var_r4 < 0) {
+		var_r4 = -var_r4;
+		while (var_r4 != 0) {
+			if (var_r4 & 1) {
+				var_f1 *= *var_r5;
+			}
+			var_r4 >>= 1;
+			var_r5++;
+		}
+	} else if (var_r4 > 0) {
+		while (var_r4 != 0) {
+			if (var_r4 & 1) {
+				var_f1 *= *var_r5;
+			}
+			var_r4 >>= 1;
+			var_r5++;
+		}
+	}
+
+	p = d->sig.text;
+	while (digits != 0) {
+		n = digits;
+		if (n > 8) {
+			n = 8;
+		}
+		chunk = 0;
+		count = n + 1;
+		while (--count != 0) {
+			chunk = chunk * 10 + (*p++ - '0');
+		}
+		x = x * digit_values[n - 1] + chunk;
+		digits -= n;
+	}
+
+	if (d->exp < 0) {
+		x /= var_f1;
+	} else {
+		x *= var_f1;
+	}
+
+	if (d->sign) {
+		x = -x;
+	}
+
+	return x;
+}


### PR DESCRIPTION
Matches `ansi_fp.c` fully and flips it to `Matching`. The DOL sha1-verifies with the unit linked.

## What was needed

`__num2dec` already matched 100% per-symbol, but linking the unit broke the DOL hash: the `.sdata2` literal pool order was wrong. The cause is the UNUSED `__dec2num` — under `-inline deferred` it is codegen'd first and pools the `0.0`/`1.0`/int-conversion-magic literals (`@268`/`@270`/`@272`) before `__num2dec` adds `0.1`/`10.0` (`@362`/`@363`). Reconstructing a `__dec2num` body that touches exactly those constants in that order restores the original pool layout. objdiff's per-symbol view cannot see this class of mismatch; only the DOL check catches it.

The reconstruction is a plausible inverse of `__num2dec` (digit-chunk accumulation via `digit_values`, power-of-ten scaling via `bit_values`), written from the binary, the linker map, and the emitted literal pool only — no external MSL sources were consulted. It is smaller than the map's record (0x13c vs 0x2a4, noted with a TODO); since the function is deadstripped, only its literal-pool side effect and symbol presence affect the link.

## Verification

- `ninja` — `build/GMSJ01/mario.dol: OK` with ansi_fp linked (SDK 147/149 linked)
- `tools/validate-symbol-order.py` — PASS (one non-failing UNUSED size warning, noted in-source)
- all symbols 100% in objdiff, `.sdata2` byte order identical to target