### PR TITLE
rework(decomp): improve MSound matching

### DIFF
--- a/include/MSound/MSound.hpp
+++ b/include/MSound/MSound.hpp
@@ -112,13 +112,21 @@ public:
 			                                             param_3, param_4);
 	}
 
-	// Fabricated, very likely due to real startSoundSystemSE
-	void startSoundActor(u32 param_1, const Vec* param_2, u32 param_3,
-	                     JAISound** param_4, u32 param_5, u8 param_6)
+	// Fabricated, very likely due to real startSoundSystemSE.
+	// Returning the handle through a named local (JAIBasic house style,
+	// cf. startSoundActorReturnHandle) is required for callers' stack
+	// frames to match, e.g. TDebuTelesa::receiveMessage.
+	// Callers that ignore the handle differ in how they spell the
+	// receiver: SMSGetMSound()-> costs two more stack words than
+	// gpMSound-> (TMapEventSink::control needs the latter).
+	JAISound* startSoundActor(u32 param_1, const Vec* param_2, u32 param_3,
+	                          JAISound** param_4, u32 param_5, u8 param_6)
 	{
+		JAISound* sound = nullptr;
 		if (gateCheck(param_1))
-			MSoundSESystem::MSoundSE::startSoundActor(
+			sound = MSoundSESystem::MSoundSE::startSoundActor(
 			    param_1, param_2, param_3, param_4, param_5, param_6);
+		return sound;
 	}
 
 	void startSoundActorWithInfo(u32 param_1, const Vec* param_2, Vec* param_3,

--- a/src/MSound/MAnmSound.cpp
+++ b/src/MSound/MAnmSound.cpp
@@ -8,6 +8,11 @@
 
 MAnmSound::MAnmSound(MSound* sound) { mData = nullptr; }
 
+void MAnmSound::initAnmSound(void* param_1, u32 param_2, f32 param_3)
+{
+	initActorAnimSound(param_1, param_2, param_3);
+}
+
 void MAnmSound::animeLoop(Vec* param_1, f32 param_2, f32 param_3, u32 param_4,
                           u8 param_5)
 {
@@ -16,20 +21,6 @@ void MAnmSound::animeLoop(Vec* param_1, f32 param_2, f32 param_3, u32 param_4,
 		                param_5);
 }
 
-void MAnmSound::initAnmSound(void* param_1, u32 param_2, f32 param_3)
-{
-	initActorAnimSound(param_1, param_2, param_3);
-}
-
-void MAnmSound::setSpeedModifySound(JAISound* param_1,
-                                    JAIAnimeFrameSoundData* param_2,
-                                    f32 param_3)
-{
-	if (MSound::getSwitch(param_1->getUnk8(), 0x100000, 0x14))
-		JAIAnimeSound::setSpeedModifySound(param_1, param_2, param_3);
-}
-
-// TODO: find a home for this
 static u32 get_thing(u32 param_1)
 {
 	u32 uVar1 = param_1 >> 30;
@@ -47,6 +38,7 @@ static u32 get_thing(u32 param_1)
 	return 0xffffffff;
 }
 
+// TODO: nonmatching, frame 0x30 vs target 0x38
 void MAnmSound::startAnimSound(void* param_1, u32 param_2, JAISound** param_3,
                                JAIActor* param_4, u8 param_5)
 {
@@ -69,6 +61,25 @@ void MAnmSound::startAnimSound(void* param_1, u32 param_2, JAISound** param_3,
 		MSoundSESystem::MSoundSE::startSoundActorInner(param_2, param_3,
 		                                               param_4, 0, param_5);
 	}
+}
+
+void MAnmSound::setSpeedModifySound(JAISound* param_1,
+                                    JAIAnimeFrameSoundData* param_2,
+                                    f32 param_3)
+{
+	if (MSound::getSwitch(param_1->getUnk8(), 0x100000, 0x14))
+		JAIAnimeSound::setSpeedModifySound(param_1, param_2, param_3);
+}
+
+f32 MSMarioPosVolume::getDistFromMario(const Vec& position)
+{
+	if (MSGMSound->cameraLooksAtMario()) {
+		const Vec* marioPosition = MSGMSound->unkAC[0].unk0;
+		return std::sqrtf(std::powf(position.x - marioPosition->x, 2.0f)
+		                  + std::powf(position.y - marioPosition->y, 2.0f)
+		                  + std::powf(position.z - marioPosition->z, 2.0f));
+	}
+	return 0.0f;
 }
 
 void MAnmSoundNPC::startAnimSound(void* param_1, u32 param_2,

--- a/src/MSound/MSound.cpp
+++ b/src/MSound/MSound.cpp
@@ -114,8 +114,12 @@ void MSSeCallBack::setWaterCameraFir(bool enabled)
 		smWaterFilter = 0;
 }
 
-void MSSeCallBack::setWaterFilter(u16 param_1) { }
+void MSSeCallBack::setWaterFilter(u16 param_1)
+{
+	smWaterFilter = param_1 > 0x78 ? 0x78 : param_1;
+}
 
+// TODO: nonmatching, register allocation and frame 0x50 vs target 0x88
 u16 MSSeCallBack::setParameterSeqSync(JASystem::TTrack* param_1, u16 param_2)
 {
 	switch (param_2) {
@@ -254,13 +258,8 @@ u16 MSSeCallBack::setParameterSeqSync(JASystem::TTrack* param_1, u16 param_2)
 		return ukuleleFlag;
 
 	case 121:
-	case 123:
-	case 124:
-	case 125:
-	case 126:
 		return ukuleleFlag;
 
-	// TODO: how to get bge? :(
 	case 127:
 		break;
 	}
@@ -423,6 +422,8 @@ f32 MSound::getDistFromCamera(Vec* pos)
 	return JALCalc::getDist(pos, unk8->unk0);
 }
 
+// TODO: nonmatching, we reload `this` from a stack home where the target
+// keeps it in a register; frame 0x70 vs target 0x88
 MSound::MSound(JKRHeap* param_1, JKRHeap* param_2, u32 param_3, u8* param_4,
                u8* param_5, u32 param_6)
 {
@@ -504,7 +505,7 @@ MSound::MSound(JKRHeap* param_1, JKRHeap* param_2, u32 param_3, u8* param_4,
 	unkA4 = 0;
 }
 
-void MSound::requestShineAppearFanfare() { }
+void MSound::requestShineAppearFanfare() { unkD1 = 1; }
 
 void MSound::mainLoop()
 {

--- a/src/MSound/MSoundSE.cpp
+++ b/src/MSound/MSoundSE.cpp
@@ -49,15 +49,13 @@ u32 MSRandVol::getRandomVolume(u32 param_1, u32 param_2) { }
 
 f32 MSRandVol::getRandVol(u32 param_1)
 {
-	f32 d = JALCalc::getRandom(unk3C[param_1 >> 24 & 0xC] * unk18,
-	                           unk2C[param_1 >> 22 & 0xC],
-	                           unk1C[param_1 >> 20 & 0xC])
-	        + 1.0f;
+	f32 step    = unk1C[param_1 >> 22 & 3];
+	f32 maximum = unk2C[param_1 >> 24 & 3];
+	f32 volume  = unk3C[param_1 >> 26 & 3] * unk18;
+	f32 d       = JALCalc::getRandom(volume, maximum, step) + 1.0f;
 
-	if (d < 0.0f)
-		return 0.0f;
-	if (d > 2.0f)
-		return 2.0f;
+	d = d < 0.0f ? 0.0f : d;
+	d = d > 2.0f ? 2.0f : d;
 	return d;
 }
 
@@ -468,6 +466,8 @@ static f32 vecLength(const Vec& vec)
 	return std::sqrtf(vec.x * vec.x + vec.y * vec.y + vec.z * vec.z);
 }
 
+// TODO: nonmatching, structural: early id check and bss addressing differ;
+// suspected tie to the startSoundActor receiver spelling in MSound.hpp
 void MSoundSE::startSoundActorWithInfo(u32 param_1, const Vec* param_2,
                                        Vec* param_3, f32 param_4, u32 param_5,
                                        u32 param_6, JAISound** param_7,
@@ -499,6 +499,9 @@ void MSoundSE::startSoundActorWithInfo(u32 param_1, const Vec* param_2,
 		else
 			param_1 += 0x4;
 		break;
+
+	case MSD_SE_OBJ_MA_MIRROR_MOVE:
+		return;
 	}
 
 	if (JALSystem::gateCheckFunc(param_1, fVar7) != true) {

--- a/src/MSound/MSoundScene.cpp
+++ b/src/MSound/MSoundScene.cpp
@@ -7,6 +7,8 @@
 #include <MSound/MSSetSound.hpp>
 #include <MSound/MSoundBGM.hpp>
 
+Vec _posByCamera[256];
+
 MSSceneSE::MSSceneSE(u32 param_1)
 {
 	for (int i = 0; i < ARRAY_COUNT(unk4); ++i)

--- a/src/MSound/MSoundStruct.cpp
+++ b/src/MSound/MSoundStruct.cpp
@@ -156,11 +156,9 @@ bool MSSetSoundTL<T>::startSoundSetDyna(u32 param_1, const Vec* param_2,
 		if (uVar7 < bVar1 + uVar5) {
 			bVar2 = false;
 		} else {
-			if (unk24.get() == 1 && unk1F.get() < uVar7 && f31 < unk20.get()) {
+			if (unk24.get() == 1 && uVar7 < unk1F.get() && f31 < unk20.get()) {
 				bVar2 = false;
 			} else {
-				// TODO: definitely an inline, non-structured control flow.
-				// Probably even two to get searchD to not inline.
 				if (param_8 != nullptr) {
 					MSSetSoundMember* candidate
 					    = param_8->searchD(unk5C[unk5A]->unk8);
@@ -254,7 +252,6 @@ bool MSSetSoundTL<T>::startSoundSetDyna(u32 param_1, const Vec* param_2,
 				snd->setVolume(f30 * f27, 3, 0);
 				snd->setPitch(f29 * f28, 3, 0);
 			} else {
-				// Huh.
 				if (unk5C[unk59] != nullptr)
 					unk5C[unk59]->setPortData(13, 1);
 				unk58 = 0;


### PR DESCRIPTION
Matching improvements across MSound (MSound, MSoundSE, MAnmSound, MSoundScene): `startSoundActor` now returns the sound handle through a named local (JAIBasic house style), which several callers' stack frames require, and callers arbitrate between the `SMSGetMSound()->` and `gpMSound->` receiver spellings where the frame demands it. No TUs flip to Matching yet; remaining residues are documented with TODO notes. The `MSound.hpp` change also appears identically in the companion core and enemy/player PRs and merges clean in any order.

## Verification
- full build from upstream main + this change: `build/GMSJ01/mario.dol: OK`