### PR TITLE
GC2D/GCConsole2: match startAppearCoin

### DIFF
--- a/src/GC2D/GCConsole2.cpp
+++ b/src/GC2D/GCConsole2.cpp
@@ -2280,7 +2280,7 @@ void TGCConsole2::startDisappearTank()
 
 void TGCConsole2::startAppearCoin()
 {
-	if (unk108->getPane()->isVisible()) {
+	if (unk108->getPane()->isVisible() != 0) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- spell the coin-counter pane visibility test explicitly
- match TGCConsole2::startAppearCoin

## Results
- GCConsole2: 26/60 -> 27/60
- project-wide: 8097/12881 -> 8098/12881

## Testing
- full bare ninja (mario.dol: OK)
- GCConsole2 symbol linkage validation
- local CI