### PR TITLE
M3DUtil/MActorAnm: wrap the MtxCalcTypeName comment to 80 columns

### DIFF
--- a/include/M3DUtil/MActorAnm.hpp
+++ b/include/M3DUtil/MActorAnm.hpp
@@ -271,9 +271,10 @@ public:
 	/* 0x28 */ J3DTexNoAnm** unk28;
 };
 
-// The names come from the MtxCalcTypeName table in M3DUtil/InfectiousStrings.hpp,
-// which survives in the ROM (read it in MarioDraw.cpp's .data): its four entries
-// are "MActorMtxCalcType_Basic", "_Softimage", "_MotionBlend" and "_User".
+// The names come from the MtxCalcTypeName table in
+// M3DUtil/InfectiousStrings.hpp, which survives in the ROM (read it in
+// MarioDraw.cpp's .data): its four entries are "MActorMtxCalcType_Basic",
+// "_Softimage", "_MotionBlend" and "_User".
 enum MActorMtxCalcType {
 	MACTOR_MTX_CALC_BASIC,
 	MACTOR_MTX_CALC_SOFTIMAGE,


### PR DESCRIPTION
One comment block, rewrapped. No code, no wording changes.

The three lines above `enum MActorMtxCalcType` landed in c19ae4d4 at 82 and 81 columns
against the repo's `ColumnLimit: 80`, so `check-format-and-tidy` fails on the file.

**This is currently failing every open pull request.** The clang-format action walks the
whole tree rather than the diff, so any PR goes red as soon as it merges `main` -- for a
violation none of them introduced. I ran into it on #154 and confirmed it is not specific
to that branch, which is why this is split out here rather than left riding on it: the
other open PRs should not have to wait on mine to go green.

It is also the only one. After this reflow, `clang-format --dry-run -Werror` across all of
`src/` and `include/` reports zero failing files.

```
-// The names come from the MtxCalcTypeName table in M3DUtil/InfectiousStrings.hpp,
-// which survives in the ROM (read it in MarioDraw.cpp's .data): its four entries
-// are "MActorMtxCalcType_Basic", "_Softimage", "_MotionBlend" and "_User".
+// The names come from the MtxCalcTypeName table in
+// M3DUtil/InfectiousStrings.hpp, which survives in the ROM (read it in
+// MarioDraw.cpp's .data): its four entries are "MActorMtxCalcType_Basic",
+// "_Softimage", "_MotionBlend" and "_User".
```

The same commit is also on #154 so that branch could go green on its own. Once this
merges, the two are identical content and #154 will fast-forward past it cleanly -- but if
you would rather it exist in only one place, say so and I will drop it from #154.